### PR TITLE
BUG change to use gnu89 on all platforms.

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -15,6 +15,7 @@ Bottleneck 0.7.0
 
 - #50 move_std, move_nanstd return inappropriate NaNs (sqrt of negative #)
 - #52 `make test` fails on some computers
+- #49, #55 now works on Mac OS X 10.8 using clang compiler
 
 Older versions
 ==============

--- a/bottleneck/src/move/setup.py
+++ b/bottleneck/src/move/setup.py
@@ -31,6 +31,7 @@ else:
 
 mod_dir = os.path.dirname(__file__)
 ext_modules = [Extension("move", [os.path.join(mod_dir, "%sbit/move.pyx") % bits],
+               extra_compile_args=["-std=gnu89"],
                include_dirs=[np.get_include()])]
 
 setup(


### PR DESCRIPTION
This fixes #49 and #55, see https://github.com/kwgoodman/bottleneck/issues/49#issuecomment-13267623 for more details.
