### PR TITLE
Additional fix related to #49. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,6 @@ setup(name=NAME,
       ext_modules=[Extension("func", sources=["bottleneck/src/func/func.c"],
                              include_dirs=[np.get_include()]),
                    Extension("move", sources=["bottleneck/src/move/move.c"],
+                             extra_compile_args=["-std=gnu89"],
                              include_dirs=[np.get_include()])]
       )


### PR DESCRIPTION
I had problems getting bottleneck to work on OS x 10.8 installed from the git repo. The issues is the same as in 
#49 which should be fixed.

It turns out that the "-std=gnu89" argument is only passed when building from cython source not from the generated C. This pull request fixes that. 
