### PR TITLE
TST: fix thousands of deprecation warnings during tests with numpy 1.8 ...

### DIFF
--- a/bottleneck/tests/partsort_test.py
+++ b/bottleneck/tests/partsort_test.py
@@ -41,7 +41,7 @@ def unit_maker(func, func0):
                 n = arr.size
             else:
                 n = arr.shape[axis]
-            n = max(n / 2, 1)
+            n = max(n // 2, 1)
             with np.errstate(invalid='ignore'):
                 actual = func(arr.copy(), n, axis=axis)
                 actual[:n] = np.sort(actual[:n], axis=axis)


### PR DESCRIPTION
...on Python 3

E.g. `partsort_test.py:47: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future`
