### PR TITLE
BUG: Fix nanargmax/nanargmin for 1D integer arguments

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -11,6 +11,9 @@ Bottleneck 0.8.0
 
 *Release date: Not yet released, in development*
 
+**Bug fixes**
+
+- nanargmax/nanargmin wrong for redundant max/min values in 1d int arrays
 
 Older versions
 ==============

--- a/bottleneck/src/template/func/nanargmax.py
+++ b/bottleneck/src/template/func/nanargmax.py
@@ -98,7 +98,7 @@ loop[1] = """\
     amax = MINDTYPE
     for iINDEX0 in range(nINDEX0):
         ai = a[INDEXALL]
-        if ai >= amax:
+        if ai > amax:
             amax = ai
             idx = iINDEX0
     return np.intp(idx)

--- a/bottleneck/src/template/func/nanargmin.py
+++ b/bottleneck/src/template/func/nanargmin.py
@@ -98,7 +98,7 @@ loop[1] = """\
     amin = MAXDTYPE
     for iINDEX0 in range(nINDEX0):
         ai = a[INDEXALL]
-        if ai <= amin:
+        if ai < amin:
             amin = ai
             idx = iINDEX0
     return np.intp(idx)

--- a/bottleneck/tests/func_test.py
+++ b/bottleneck/tests/func_test.py
@@ -27,6 +27,8 @@ def arrays(dtypes=bn.dtypes, nans=True):
                 a = a.reshape(shape)
                 yield a
                 yield -a
+                # nanargmax/nanargmin regression tests
+                yield np.zeros_like(a)
             if issubclass(a.dtype.type, np.inexact):
                 if nans:
                     for i in range(a.size):


### PR DESCRIPTION
These functions should return the argument of the _first_ max/min value (like
numpy). This was not the case in the current release, since there is special
logic for 1D integer arrays (they are iterated through forwards instead of
backwards like all other array types).
