### PR TITLE
Fix build error `AttributeError: 'dict' object has no attribute ...`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,11 @@ class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # prevent numpy from thinking it is still in its setup process
-        __builtins__.__NUMPY_SETUP__ = False
+        if sys.version_info < (3,):
+            import __builtin__ as builtins
+        else:
+            import builtins
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         # place numpy includes first, see gh #156
         self.include_dirs.insert(0, numpy.get_include())


### PR DESCRIPTION
Running `pip wheel ./`  in the source checkout with pip>19.0 fails with a `AttributeError: 'dict' object has no attribute __NUMPY_SETUP__`

Depending on how the setup.py script is executed (as `__main__` or not) `__builtins__` in the global namespace can be a dictionary or a module (https://docs.python.org/3/library/builtins.html says it can be either and that this is an cpython implementation detail).

Fixed by an explicit import.