### PR TITLE
BENCH: add initial asv suite covering reductions

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -1,0 +1,190 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "bottleneck",
+
+    // The project's homepage
+    "project_url": "http://github.com/pydata/bottleneck",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "..",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py bdist_wheel"
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/pydata/bottleneck/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["2.7", "3.7"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    "conda_channels": ["defaults"],
+
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    "matrix": {
+	"req": {
+	    "numpy": ["1.16"],
+	},
+	"env": {
+	    "CC": ["gcc"],
+	    "CXX": ["g++"],
+	}
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    "include": [
+	{
+	    "req": {
+		"numpy": "1.16",
+	    },
+	    "env": {
+		"CC": "clang",
+		"CXX": "clang++",
+	    },
+	    "python": "3.7"
+	}
+    ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    "build_cache_size": 8,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/asv_bench/benchmarks/reduce.py
+++ b/asv_bench/benchmarks/reduce.py
@@ -1,0 +1,164 @@
+import bottleneck as bn
+import numpy as np
+
+
+RAND_ARRAY_CACHE = {}
+
+
+def get_cached_rand_array(shape, dtype, order):
+    key = (shape, dtype, order)
+    if key not in RAND_ARRAY_CACHE:
+        assert order in ["C", "F"]
+        random_state = np.random.RandomState(1234)
+        if "int" in shape:
+            dtype_info = np.iinfo(dtype)
+            arr = random_state.randint(
+                dtype_info.min, dtype_info.max, size=shape, dtype=dtype
+            )
+        else:
+            arr = 10000 * random_state.standard_normal(shape).astype(dtype)
+
+        if order == "F":
+            arr = np.asfortranarray(arr)
+
+        assert arr.flags[order + "_CONTIGUOUS"]
+
+        RAND_ARRAY_CACHE[key] = arr
+
+    return RAND_ARRAY_CACHE[key].copy(order=order)
+
+
+class Time1DReductions:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3,), (10 ** 5,), (10 ** 7,)],
+    ]
+    param_names = ["dtype", "shape"]
+
+    def setup(self, dtype, shape):
+        self.arr = get_cached_rand_array(shape, dtype, "C")
+
+    def time_nanmin(self, dtype, shape):
+        bn.nanmin(self.arr)
+
+    def time_nanmax(self, dtype, shape):
+        bn.nanmin(self.arr)
+
+    def time_nanargmin(self, dtype, shape):
+        bn.nanargmin(self.arr)
+
+    def time_nanargmax(self, dtype, shape):
+        bn.nanargmax(self.arr)
+
+    def time_nansum(self, dtype, shape):
+        bn.nansum(self.arr)
+
+    def time_nanmean(self, dtype, shape):
+        bn.nanmean(self.arr)
+
+    def time_nanstd(self, dtype, shape):
+        bn.nanstd(self.arr)
+
+    def time_nanvar(self, dtype, shape):
+        bn.nanvar(self.arr)
+
+    def time_median(self, dtype, shape):
+        bn.median(self.arr)
+
+    def time_nanmedian(self, dtype, shape):
+        bn.nanmedian(self.arr)
+
+    def time_ss(self, dtype, shape):
+        bn.ss(self.arr)
+
+
+class Time2DReductions:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3, 10 ** 3)],
+        ["C", "F"],
+        [None, 0, 1],
+    ]
+    param_names = ["dtype", "shape", "order", "axis"]
+
+    def setup(self, dtype, shape, order, axis):
+        self.arr = get_cached_rand_array(shape, dtype, order)
+
+    def time_nanmin(self, dtype, shape, order, axis):
+        bn.nanmin(self.arr, axis=axis)
+
+    def time_nanmax(self, dtype, shape, order, axis):
+        bn.nanmin(self.arr, axis=axis)
+
+    def time_nanargmin(self, dtype, shape, order, axis):
+        bn.nanargmin(self.arr, axis=axis)
+
+    def time_nanargmax(self, dtype, shape, order, axis):
+        bn.nanargmax(self.arr, axis=axis)
+
+    def time_nansum(self, dtype, shape, order, axis):
+        bn.nansum(self.arr, axis=axis)
+
+    def time_nanmean(self, dtype, shape, order, axis):
+        bn.nanmean(self.arr, axis=axis)
+
+    def time_nanstd(self, dtype, shape, order, axis):
+        bn.nanstd(self.arr, axis=axis)
+
+    def time_nanvar(self, dtype, shape, order, axis):
+        bn.nanvar(self.arr, axis=axis)
+
+    def time_median(self, dtype, shape, order, axis):
+        bn.median(self.arr, axis=axis)
+
+    def time_nanmedian(self, dtype, shape, order, axis):
+        bn.nanmedian(self.arr, axis=axis)
+
+    def time_ss(self, dtype, shape, order, axis):
+        bn.ss(self.arr, axis=axis)
+
+
+class TimeAnyNan2D:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3, 10 ** 3)],
+        ["C", "F"],
+        [None, 0, 1],
+        ["fast", "slow"],
+    ]
+    param_names = ["dtype", "shape", "order", "axis", "case"]
+
+    def setup(self, dtype, shape, order, axis, case):
+        self.arr = np.full(shape, 0, dtype=dtype, order=order)
+
+        if "float" in dtype:
+            if case == "fast":
+                self.arr[:] = np.nan
+
+        assert self.arr.flags[order + "_CONTIGUOUS"]
+
+    def time_anynan(self, dtype, shape, order, axis, case):
+        bn.anynan(self.arr, axis=axis)
+
+
+class TimeAllNan2D:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3, 10 ** 3)],
+        ["C", "F"],
+        [None, 0, 1],
+        ["fast", "slow"],
+    ]
+    param_names = ["dtype", "shape", "order", "axis", "case"]
+
+    def setup(self, dtype, shape, order, axis, case):
+        self.arr = np.full(shape, 0, dtype=dtype, order=order)
+
+        if "float" in dtype:
+            if case == "slow":
+                self.arr[:] = np.nan
+
+        assert self.arr.flags[order + "_CONTIGUOUS"]
+
+    def time_anynan(self, dtype, shape, order, axis, case):
+        bn.anynan(self.arr, axis=axis)


### PR DESCRIPTION
Add a basic `asv` setup covering `bottleneck.reduce` for the following combinations:

- Python 2.7 and 3.7
- Both `gcc` and `clang`
- Both `C` and `F` ordering
- All supported types
- Both 1-D and 2-D arrays
- Also spanning 10^3 to 10^7 elements

The good (and bad) news is that this suite identifies a decent number of regressions and performance discrepancies. Current output available at https://qwhelan.github.io/bottleneck/
