### PR TITLE
[TST] Switch from nose to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         # test installing bottleneck tarball before installing numpy;
         # start this test first because it takes the longest
         - os: linux
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="2.7"
                PYTHON_ARCH="64"
                TEST_RUN="sdist"
@@ -23,7 +23,7 @@ matrix:
 
         # python 3.5
         - os: linux
-          env: TEST_DEPS="nose"
+          env: TEST_DEPS="pytest"
                PIP_DEPS="numpy>=1.16"
                PYTHON_VERSION="3.5"
                PYTHON_ARCH="64"
@@ -31,46 +31,46 @@ matrix:
 
          # python 3.6
         - os: linux
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="3.6"
                PYTHON_ARCH="64"
 
          # python 3.7 conda numpy
         - os: linux
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
          # python 3.7 conda numpy + sdist
         - os: linux
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
                TEST_RUN="sdist"
 
         # python 2.7
         - os: osx
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="2.7"
                PYTHON_ARCH="64"
                TEST_RUN="sdist"
 
         # python 3.5
         - os: osx
-          env: TEST_DEPS="nose"
+          env: TEST_DEPS="pytest"
                PIP_DEPS="numpy>=1.16"
                PYTHON_VERSION="3.5"
                PYTHON_ARCH="64"
 
         # python 3.6
         - os: osx
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="3.6"
                PYTHON_ARCH="64"
 
         # python 3.7
         - os: osx
-          env: TEST_DEPS="numpy nose"
+          env: TEST_DEPS="numpy pytest"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ shallow_clone: false # download the zip instead of the whole history
 environment:
 
     global:
-        DEPS: "numpy nose"
+        DEPS: "numpy pytest"
         CONDA_VENV: "testy"
         # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
         # /E:ON and /V:ON options are not enabled in the batch script
@@ -23,14 +23,14 @@ environment:
 
         - PYTHON_VERSION: "3.5"
           PYTHON_ARCH: "32"
-          DEPS: "nose"
+          DEPS: "pytest"
           PIP_DEPS: "numpy>=1.16"
           platform: x86
           CONDA_HOME: "C:\\Miniconda3"
 
         - PYTHON_VERSION: "3.5"
           PYTHON_ARCH: "64"
-          DEPS: "nose"
+          DEPS: "pytest"
           PIP_DEPS: "numpy>=1.16"
           platform: x64
           CONDA_HOME: "C:\\Miniconda3-x64"
@@ -65,4 +65,5 @@ build: false
 test_script:
     - "activate %CONDA_VENV%"
     - "%CMD_IN_ENV% pip install ."
+    - "%CMD_IN_ENV% python setup.py build_ext --inplace"
     - "python tools\\test-installed-bottleneck.py"

--- a/bottleneck/__init__.py
+++ b/bottleneck/__init__.py
@@ -14,9 +14,9 @@ from bottleneck.benchmark.bench import bench
 from bottleneck.benchmark.bench_detailed import bench_detailed
 from bottleneck.tests.util import get_functions
 
-from numpy.testing import Tester
-test = Tester().test
-del Tester
+from ._pytesttester import PytestTester
+test = PytestTester(__name__)
+del PytestTester
 
 from ._version import get_versions  # noqa: E402
 __version__ = get_versions()['version']

--- a/bottleneck/_pytesttester.py
+++ b/bottleneck/_pytesttester.py
@@ -1,0 +1,77 @@
+"""
+Generic test utilities.
+
+Based on scipy._libs._testutils
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import sys
+
+
+__all__ = ['PytestTester']
+
+
+class PytestTester(object):
+    """
+    Pytest test runner entry point.
+    """
+
+    def __init__(self, module_name):
+        self.module_name = module_name
+
+    def __call__(self, label="fast", verbose=1, extra_argv=None, doctests=False,
+                 coverage=False, tests=None, parallel=None):
+        import pytest
+
+        module = sys.modules[self.module_name]
+        module_path = os.path.abspath(module.__path__[0])
+
+        pytest_args = ['-l']
+
+        if doctests:
+            raise ValueError("Doctests not supported")
+
+        if extra_argv:
+            pytest_args += list(extra_argv)
+
+        if verbose and int(verbose) > 1:
+            pytest_args += ["-" + "v" * (int(verbose) - 1)]
+
+        if coverage:
+            pytest_args += ["--cov=" + module_path]
+
+        if label == "fast":
+            pytest_args += ["-m", "not slow"]
+        elif label != "full":
+            pytest_args += ["-m", label]
+
+        if tests is None:
+            tests = [self.module_name]
+
+        if parallel is not None and parallel > 1:
+            if _pytest_has_xdist():
+                pytest_args += ['-n', str(parallel)]
+            else:
+                import warnings
+                warnings.warn('Could not run tests in parallel because '
+                              'pytest-xdist plugin is not available.')
+
+        pytest_args += ['--pyargs'] + list(tests)
+
+        try:
+            code = pytest.main(pytest_args)
+        except SystemExit as exc:
+            code = exc.code
+
+        return (code == 0)
+
+
+def _pytest_has_xdist():
+    """
+    Check if the pytest-xdist plugin is installed, providing parallel tests
+    """
+    # Check xdist exists without importing, otherwise pytests emits warnings
+    from importlib.util import find_spec
+    return find_spec('xdist') is not None

--- a/bottleneck/tests/input_modification_test.py
+++ b/bottleneck/tests/input_modification_test.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_equal
 import bottleneck as bn
 from .util import DTYPES
+import pytest
 
 
 def arrays(dtypes):
@@ -32,7 +33,8 @@ def arrays(dtypes):
                 yield a
 
 
-def unit_maker(func, nans=True):
+@pytest.mark.parametrize("func", bn.get_functions('all'))
+def test_modification(func, nans=True):
     "Test that bn.xxx gives the same output as np.xxx."
     msg = "\nInput array modified by %s.\n\n"
     msg += "input array before:\n%s\nafter:\n%s\n"
@@ -55,9 +57,3 @@ def unit_maker(func, nans=True):
                     except:  # noqa
                         continue
                 assert_equal(a1, a2, msg % (func.__name__, a1, a2))
-
-
-def test_modification():
-    "Test for illegal inplace modification of input array"
-    for func in bn.get_functions('all'):
-        yield unit_maker, func

--- a/bottleneck/tests/list_input_test.py
+++ b/bottleneck/tests/list_input_test.py
@@ -6,13 +6,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 import bottleneck as bn
 from .util import DTYPES
-
-
-def test_list_input():
-    "Check that functions can handle list input"
-    for func in bn.get_functions('all'):
-        if func.__name__ != 'replace':
-            yield unit_maker, func
+import pytest
 
 
 def lists(dtypes=DTYPES):
@@ -32,11 +26,14 @@ def lists(dtypes=DTYPES):
                 yield a.astype(dtype).tolist()
 
 
-def unit_maker(func):
+@pytest.mark.parametrize("func", bn.get_functions('all'))
+def test_list_input(func):
     "Test that bn.xxx gives the same output as bn.slow.xxx for list input."
     msg = '\nfunc %s | input %s (%s) | shape %s\n'
     msg += '\nInput array:\n%s\n'
     name = func.__name__
+    if name == 'replace':
+        return
     func0 = eval('bn.slow.%s' % name)
     for i, a in enumerate(lists()):
         with warnings.catch_warnings():

--- a/bottleneck/tests/move_test.py
+++ b/bottleneck/tests/move_test.py
@@ -5,15 +5,11 @@ from numpy.testing import (assert_equal, assert_array_almost_equal,
                            assert_raises)
 import bottleneck as bn
 from .util import arrays, array_order
+import pytest
 
 
-def test_move():
-    "test move functions"
-    for func in bn.get_functions('move'):
-        yield unit_maker, func
-
-
-def unit_maker(func):
+@pytest.mark.parametrize("func", bn.get_functions('move'))
+def test_move(func):
     "Test that bn.xxx gives the same output as a reference function."
     fmt = ('\nfunc %s | window %d | min_count %s | input %s (%s) | shape %s | '
            'axis %s | order %s\n')
@@ -48,13 +44,9 @@ def unit_maker(func):
 # ---------------------------------------------------------------------------
 # Test argument parsing
 
-def test_arg_parsing():
-    "test argument parsing"
-    for func in bn.get_functions('move'):
-        yield unit_maker_argparse, func
 
-
-def unit_maker_argparse(func, decimal=5):
+@pytest.mark.parametrize("func", bn.get_functions('move'))
+def test_arg_parsing(func, decimal=5):
     "test argument parsing."
 
     name = func.__name__
@@ -118,13 +110,8 @@ def unit_maker_argparse(func, decimal=5):
     func(*args, **kwargs)
 
 
-def test_arg_parse_raises():
-    "test argument parsing raises in move"
-    for func in bn.get_functions('move'):
-        yield unit_maker_argparse_raises, func
-
-
-def unit_maker_argparse_raises(func):
+@pytest.mark.parametrize("func", bn.get_functions('move'))
+def test_arg_parse_raises(func):
     "test argument parsing raises in move"
     a = np.array([1., 2, 3])
     assert_raises(TypeError, func)

--- a/bottleneck/tests/nonreduce_axis_test.py
+++ b/bottleneck/tests/nonreduce_axis_test.py
@@ -6,24 +6,14 @@ import bottleneck as bn
 from .reduce_test import (unit_maker as reduce_unit_maker,
                           unit_maker_argparse as unit_maker_parse_rankdata)
 from .util import arrays, array_order
-
+import pytest
 
 # ---------------------------------------------------------------------------
 # partition, argpartition
 
-def test_partition():
-    "test partition"
-    for func in (bn.partition,):
-        yield unit_maker, func
 
-
-def test_argpartition():
-    "test argpartition"
-    for func in (bn.argpartition,):
-        yield unit_maker, func
-
-
-def unit_maker(func):
+@pytest.mark.parametrize("func", (bn.partition, bn.argpartition))
+def test_partition_and_argpartition(func):
     "test partition or argpartition"
 
     msg = '\nfunc %s | input %s (%s) | shape %s | n %d | axis %s | order %s\n'
@@ -135,11 +125,10 @@ def test_transpose():
 # ---------------------------------------------------------------------------
 # rankdata, nanrankdata, push
 
-def test_nonreduce_axis():
+@pytest.mark.parametrize("func", (bn.rankdata, bn.nanrankdata, bn.push))
+def test_nonreduce_axis(func):
     "Test nonreduce axis functions"
-    funcs = [bn.rankdata, bn.nanrankdata, bn.push]
-    for func in funcs:
-        yield reduce_unit_maker, func
+    return reduce_unit_maker(func)
 
 
 def test_push():
@@ -155,20 +144,20 @@ def test_push():
 # ---------------------------------------------------------------------------
 # Test argument parsing
 
-def test_arg_parsing():
+@pytest.mark.parametrize("func", bn.get_functions('nonreduce_axis'))
+def test_arg_parsing(func):
     "test argument parsing in nonreduce_axis"
-    for func in bn.get_functions('nonreduce_axis'):
-        name = func.__name__
-        if name in ('partition', 'argpartition'):
-            yield unit_maker_parse, func
-        elif name in ('push'):
-            yield unit_maker_parse, func
-        elif name in ('rankdata', 'nanrankdata'):
-            yield unit_maker_parse_rankdata, func
-        else:
-            fmt = "``%s` is an unknown nonreduce_axis function"
-            raise ValueError(fmt % name)
-        yield unit_maker_raises, func
+    name = func.__name__
+    if name in ('partition', 'argpartition'):
+        return unit_maker_parse(func)
+    elif name in ('push'):
+        return unit_maker_parse(func)
+    elif name in ('rankdata', 'nanrankdata'):
+        return unit_maker_parse_rankdata(func)
+    else:
+        fmt = "``%s` is an unknown nonreduce_axis function"
+        raise ValueError(fmt % name)
+    return unit_maker_raises(func)
 
 
 def unit_maker_parse(func, decimal=5):

--- a/bottleneck/tests/nonreduce_test.py
+++ b/bottleneck/tests/nonreduce_test.py
@@ -6,15 +6,11 @@ import numpy as np
 from numpy.testing import assert_equal, assert_array_equal, assert_raises
 import bottleneck as bn
 from .util import arrays, array_order
+import pytest
 
 
-def test_nonreduce():
-    "test nonreduce functions"
-    for func in bn.get_functions('nonreduce'):
-        yield unit_maker, func
-
-
-def unit_maker(func):
+@pytest.mark.parametrize("func", bn.get_functions('nonreduce'))
+def test_nonreduce(func):
     "Test that bn.xxx gives the same output as np.xxx."
     msg = '\nfunc %s | input %s (%s) | shape %s | old %f | new %f | order %s\n'
     msg += '\nInput array:\n%s\n'

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -10,12 +10,13 @@ from numpy.testing import (assert_equal, assert_raises,
 
 import bottleneck as bn
 from .util import arrays, array_order, DTYPES
+import pytest
 
 
-def test_reduce():
+@pytest.mark.parametrize("func", bn.get_functions("reduce"))
+def test_reduce(func):
     "test reduce functions"
-    for func in bn.get_functions('reduce'):
-        yield unit_maker, func
+    return unit_maker(func)
 
 
 def unit_maker(func, decimal=5, skip_dtype=['nansum', 'ss']):
@@ -71,10 +72,10 @@ def unit_maker(func, decimal=5, skip_dtype=['nansum', 'ss']):
 # ---------------------------------------------------------------------------
 # Test argument parsing
 
-def test_arg_parsing():
+@pytest.mark.parametrize("func", bn.get_functions("reduce"))
+def test_arg_parsing(func):
     "test argument parsing"
-    for func in bn.get_functions('reduce'):
-        yield unit_maker_argparse, func
+    return unit_maker_argparse(func)
 
 
 def unit_maker_argparse(func, decimal=5):
@@ -125,10 +126,10 @@ def unit_maker_argparse(func, decimal=5):
     func(*args, **kwargs)
 
 
-def test_arg_parse_raises():
+@pytest.mark.parametrize("func", bn.get_functions("reduce"))
+def test_arg_parse_raises(func):
     "test argument parsing raises in reduce"
-    for func in bn.get_functions('reduce'):
-        yield unit_maker_argparse_raises, func
+    return unit_maker_argparse_raises(func)
 
 
 def unit_maker_argparse_raises(func):

--- a/bottleneck/tests/scalar_input_test.py
+++ b/bottleneck/tests/scalar_input_test.py
@@ -2,10 +2,15 @@
 
 from numpy.testing import assert_array_almost_equal
 import bottleneck as bn
+import pytest
 
-
-def unit_maker(func, func0, args=tuple()):
+@pytest.mark.parametrize("func", bn.get_functions('reduce') +  # noqa: W504
+                         bn.get_functions('nonreduce_axis'))
+def test_scalar_input(func, args=tuple()):
     "Test that bn.xxx gives the same output as bn.slow.xxx for scalar input."
+    if func.__name__ in ('partition', 'argpartition', 'push'):
+        return
+    func0 = eval('bn.slow.%s' % func.__name__)
     msg = '\nfunc %s | input %s\n'
     a = -9
     argsi = [a] + list(args)
@@ -13,11 +18,3 @@ def unit_maker(func, func0, args=tuple()):
     desired = func0(*argsi)
     err_msg = msg % (func.__name__, a)
     assert_array_almost_equal(actual, desired, err_msg=err_msg)
-
-
-def test_scalar_input():
-    "Test scalar input"
-    funcs = bn.get_functions('reduce') + bn.get_functions('nonreduce_axis')
-    for func in funcs:
-        if func.__name__ not in ('partition', 'argpartition', 'push'):
-            yield unit_maker, func, eval('bn.slow.%s' % func.__name__)

--- a/tools/test-installed-bottleneck.py
+++ b/tools/test-installed-bottleneck.py
@@ -46,7 +46,7 @@ result = bottleneck.test(options.mode,
                          doctests=options.doctests,
                          coverage=options.coverage)
 
-if result.wasSuccessful():
+if result:
     sys.exit(0)
 else:
     sys.exit(1)

--- a/tools/travis/bn_setup.sh
+++ b/tools/travis/bn_setup.sh
@@ -12,7 +12,8 @@ else
     else
         pip install "."
     fi
-    # Workaround for https://github.com/travis-ci/travis-ci/issues/6522
+    python setup.py build_ext --inplace
     set +e
+    # Workaround for https://github.com/travis-ci/travis-ci/issues/6522
     python "tools/test-installed-bottleneck.py"
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Tox (http://tox.testrun.org/) configuration
 
 [tox]
-envlist =  py27, py35
+envlist =  py27, py37
 
 [testenv]
 changedir={envdir}
@@ -10,18 +10,18 @@ commands={envpython} {toxinidir}/tools/test-installed-bottleneck.py {posargs:}
 [testenv:py27]
 basepython = python2.7
 deps =
-    nose
+    pytest
     numpy
 
-[testenv:py35]
-basepython = python3.5
+[testenv:py37]
+basepython = python3.7
 deps =
-    nose
+    pytest
     numpy
 
 # Not run by default. Use 'tox -e py27_npmaster' to call it
-[testenv:py27_npmaster]
-basepython = python2.7
+[testenv:py37_npmaster]
+basepython = python3.7
 deps =
-    nose
+    pytest
     https://github.com/numpy/numpy/zipball/master


### PR DESCRIPTION
The `nose` project has been unmaintained for several years now, so switch to `py.test` just like `numpy` has.