### PR TITLE
PERF: Add BN_OPT_3 to allow enabling -O3 at the function level 

### DIFF
--- a/asv_bench/benchmarks/reduce.py
+++ b/asv_bench/benchmarks/reduce.py
@@ -160,5 +160,5 @@ class TimeAllNan2D:
 
         assert self.arr.flags[order + "_CONTIGUOUS"]
 
-    def time_anynan(self, dtype, shape, order, axis, case):
-        bn.anynan(self.arr, axis=axis)
+    def time_allnan(self, dtype, shape, order, axis, case):
+        bn.allnan(self.arr, axis=axis)

--- a/bottleneck/src/bottleneck.h
+++ b/bottleneck/src/bottleneck.h
@@ -44,7 +44,7 @@
 #define MEMORY_ERR(text)  PyErr_SetString(PyExc_MemoryError, text)
 #define RUNTIME_ERR(text) PyErr_SetString(PyExc_RuntimeError, text)
 
-/* `inline` copied from NumPy. */
+/* `inline` and `opt_3` copied from NumPy. */
 #if defined(_MSC_VER)
         #define BN_INLINE __inline
 #elif defined(__GNUC__)
@@ -55,6 +55,12 @@
 	#endif
 #else
         #define BN_INLINE
+#endif
+
+#if HAVE_ATTRIBUTE_OPTIMIZE_OPT_3
+    #define BN_OPT_3 __attribute__((optimize("O3")))
+#else
+    #define BN_OPT_3
 #endif
 
 /*

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1001,11 +1001,13 @@ REDUCE_ONE(anynan, DTYPE0)
 /* dtype end */
 
 /* dtype = [['int64'], ['int32']] */
+BN_OPT_3
 REDUCE_ALL(anynan, DTYPE0)
 {
     Py_RETURN_FALSE;
 }
 
+BN_OPT_3
 REDUCE_ONE(anynan, DTYPE0)
 {
     INIT_ONE(BOOL, uint8)
@@ -1073,12 +1075,14 @@ REDUCE_ONE(allnan, DTYPE0)
 /* dtype end */
 
 /* dtype = [['int64'], ['int32']] */
+BN_OPT_3
 REDUCE_ALL(allnan, DTYPE0)
 {
     if (PyArray_SIZE(a) == 0) Py_RETURN_TRUE;
     Py_RETURN_FALSE;
 }
 
+BN_OPT_3
 REDUCE_ONE(allnan, DTYPE0)
 {
     INIT_ONE(BOOL, uint8)


### PR DESCRIPTION
Enable BN_OPT_3 for anynan/allnan for a 2x speedup. `asv` results:
```
$ asv compare HEAD^^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [f44d5ece]       [c77a69d0]
     <o3~2>           <o3>      
-         950±4ns         541±30ns     0.57  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         960±9ns         539±10ns     0.56  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         964±5ns         540±20ns     0.56  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        949±10ns          530±8ns     0.56  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        956±20ns          534±4ns     0.56  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        947±10ns          526±2ns     0.56  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        953±10ns          529±7ns     0.56  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         957±9ns         531±10ns     0.56  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        945±20ns          525±6ns     0.56  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         955±4ns          530±5ns     0.56  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         954±2ns          530±3ns     0.56  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         963±7ns          533±9ns     0.55  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        960±10ns         531±20ns     0.55  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         949±8ns          524±4ns     0.55  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        959±10ns          530±8ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         956±5ns          528±5ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        955±20ns          526±3ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        941±20ns         518±20ns     0.55  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        961±10ns         528±10ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         947±5ns          519±4ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        965±10ns          529±3ns     0.55  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        959±10ns          526±4ns     0.55  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        962±10ns         526±20ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         953±5ns          522±2ns     0.55  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         947±5ns          517±2ns     0.55  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         947±5ns          517±4ns     0.55  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         949±5ns         518±20ns     0.55  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         946±2ns          516±2ns     0.55  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         946±6ns          515±1ns     0.54  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         945±5ns          515±2ns     0.54  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         941±6ns          512±7ns     0.54  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        949±10ns          516±2ns     0.54  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         948±3ns          515±2ns     0.54  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        970±20ns         527±10ns     0.54  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         945±3ns         513±10ns     0.54  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         944±4ns          511±3ns     0.54  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         948±1ns          512±3ns     0.54  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        966±10ns          521±7ns     0.54  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         943±5ns          509±3ns     0.54  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         945±8ns          509±9ns     0.54  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         946±3ns          510±8ns     0.54  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         946±5ns          509±3ns     0.54  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         949±9ns          510±3ns     0.54  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         946±7ns          508±5ns     0.54  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         949±5ns         510±10ns     0.54  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        944±20ns          507±4ns     0.54  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         949±3ns          508±9ns     0.54  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         950±6ns          508±1ns     0.54  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         950±2ns          508±9ns     0.53  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         951±4ns         507±20ns     0.53  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        953±20ns          508±4ns     0.53  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         961±7ns          511±3ns     0.53  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         957±2ns          508±6ns     0.53  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        959±20ns          506±1ns     0.53  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         953±5ns         503±10ns     0.53  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        945±10ns         499±20ns     0.53  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         945±3ns          499±6ns     0.53  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        946±10ns         499±30ns     0.53  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 0, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        958±10ns         505±10ns     0.53  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         962±9ns          505±6ns     0.52  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         947±4ns          497±4ns     0.52  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         948±3ns          497±6ns     0.52  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        969±20ns          507±2ns     0.52  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         948±5ns          496±4ns     0.52  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]

```