### PR TITLE
PERF: speed up replace() up to 4x via more explicit typing on input array

### DIFF
--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -19,26 +19,28 @@ nonreducer(char *name,
 /* replace --------------------------------------------------------------- */
 
 /* dtype = [['float64'], ['float32']] */
-static PyObject *
+static BN_OPT_3 PyObject *
 replace_DTYPE0(PyArrayObject *a, double old, double new)
 {
-    npy_DTYPE0 ai;
     iter it;
     init_iter_all(&it, a, 0, 1);
     BN_BEGIN_ALLOW_THREADS
+    const npy_DTYPE0 oldf = (npy_DTYPE0)old;
+    const npy_DTYPE0 newf = (npy_DTYPE0)new;
     if (old == old) {
         WHILE {
+            npy_DTYPE0* array = PA(DTYPE0);
             FOR {
-                if (AI(DTYPE0) == old) AI(DTYPE0) = new;
+                array[it.i] = array[it.i] == oldf ? newf : array[it.i];
             }
             NEXT
         }
     }
     else {
         WHILE {
+            npy_DTYPE0* array = PA(DTYPE0);
             FOR {
-                ai = AI(DTYPE0);
-                if (ai != ai) AI(DTYPE0) = new;
+                array[it.i] = array[it.i] != array[it.i] ? newf : array[it.i];
             }
             NEXT
         }
@@ -51,15 +53,14 @@ replace_DTYPE0(PyArrayObject *a, double old, double new)
 
 
 /* dtype = [['int64'], ['int32']] */
-static PyObject *
+static BN_OPT_3 PyObject *
 replace_DTYPE0(PyArrayObject *a, double old, double new)
 {
-    npy_DTYPE0 oldint, newint;
     iter it;
     init_iter_all(&it, a, 0, 1);
     if (old == old) {
-        oldint = (npy_DTYPE0)old;
-        newint = (npy_DTYPE0)new;
+        const npy_DTYPE0 oldint = (npy_DTYPE0)old;
+        const npy_DTYPE0 newint = (npy_DTYPE0)new;
         if (oldint != old) {
             VALUE_ERR("Cannot safely cast `old` to int");
             return NULL;
@@ -70,8 +71,11 @@ replace_DTYPE0(PyArrayObject *a, double old, double new)
         }
         BN_BEGIN_ALLOW_THREADS
         WHILE {
-            FOR {
-                if (AI(DTYPE0) == oldint) AI(DTYPE0) = newint;
+            npy_DTYPE0* array = (npy_DTYPE0 *)it.pa;
+            npy_intp i;
+            // clang has a large perf regression when using the FOR macro here
+            for (i=0; i < it.length; i++) {
+                array[i] = array[i] == oldint ? newint : array[i];
             }
             NEXT
         }


### PR DESCRIPTION
This PR enables vectorization in `replace`, leading to a 4x speedup for `np.int32` and smaller speedups for `np.int64` and `np.float32`.
```
       before           after         ratio
     [0c710b14]       [af7c2142]
     <replace~1>       <replace> 
-     1.03±0.01ms         650±10μs     0.63  nonreduce.TimeReplace2D.time_replace('int64', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.06±0.01ms          667±6μs     0.63  nonreduce.TimeReplace2D.time_replace('int64', (1000, 1000), 'F') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-     1.03±0.01ms         648±10μs     0.63  nonreduce.TimeReplace2D.time_replace('int64', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.07±0.05ms          662±9μs     0.62  nonreduce.TimeReplace2D.time_replace('int64', (1000, 1000), 'C') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-         592±7μs         241±30μs     0.41  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-       610±300μs         243±20μs     0.40  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        590±20μs          231±2μs     0.39  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         643±4μs         251±20μs     0.39  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'F') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        597±10μs          233±4μs     0.39  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         652±9μs         249±30μs     0.38  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'C') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-        647±60μs         239±20μs     0.37  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-       689±100μs         236±20μs     0.34  nonreduce.TimeReplace2D.time_replace('float32', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         994±5μs          237±4μs     0.24  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         999±8μs         237±20μs     0.24  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.03±0.04ms         240±20μs     0.23  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'F') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      1.12±0.1ms         250±30μs     0.22  nonreduce.TimeReplace2D.time_replace('int32', (1000, 1000), 'C') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
       before           after         ratio
     [0c710b14]       [af7c2142]
     <replace~1>       <replace> 
+        630±10μs         812±70μs     1.29  nonreduce.TimeReplace2D.time_replace('float64', (1000, 1000), 'F') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+        704±10μs         880±40μs     1.25  nonreduce.TimeReplace2D.time_replace('float64', (1000, 1000), 'C') [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
+         636±9μs         784±60μs     1.23  nonreduce.TimeReplace2D.time_replace('float64', (1000, 1000), 'C') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
```

We see slight slowdowns for `np.float64` in certain cases, but I think the tradeoff is worth it. There seems to be some speedup opportunities in `np.float64` (~3x slower than `np.float32` rather than the expected ~2x), but we'll leave that for a future PR.