### PR TITLE
CLN: automatically determine correct "inline" alias and define in bn_config.h

### DIFF
--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -2,19 +2,103 @@
 Unfortunately that file is not exposed, so re-implement the portions we need.
 """
 import os
-from numpy.distutils.command.autodist import check_gcc_function_attribute
+import textwrap
 
-OPTIONAL_FUNCTION_ATTRIBUTES = [("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3",
-                                 '__attribute__((optimize("O3")))')]
+OPTIONAL_FUNCTION_ATTRIBUTES = [
+    ("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3", '__attribute__((optimize("O3")))')
+]
+
+
+def _get_compiler_list(cmd):
+    """ Return the compiler command as a list of strings. Distutils provides a
+    wildly inconsistent API here:
+      - UnixCCompiler returns a list
+      - MSVCCompiler intentionally doesn't set this variable
+      - CygwinCompiler returns a string
+
+    As we are focused on identifying gcc vs clang right now, we ignore MSVC's
+    bad result and convert all results into lists of strings
+    """
+    compiler = getattr(cmd.compiler, "compiler", "")
+    if isinstance(compiler, str):
+        compiler = compiler.split()
+    return compiler
+
+
+def is_gcc(cmd):
+    return any("gcc" in x for x in _get_compiler_list(cmd))
+
+
+def is_clang(cmd):
+    return any("clang" in x for x in _get_compiler_list(cmd))
+
+
+def check_inline(cmd):
+    """Return the inline identifier (may be empty)."""
+    cmd._check_compiler()
+    body = textwrap.dedent(
+        """
+        #ifndef __cplusplus
+        static %(inline)s int static_func (void)
+        {
+            return 0;
+        }
+        %(inline)s int nostatic_func (void)
+        {
+            return 0;
+        }
+        #endif
+        int main(void) {
+            int r1 = static_func();
+            int r2 = nostatic_func();
+            return r1 + r2;
+        }
+        """
+    )
+
+    for kw in ["inline", "__inline__", "__inline"]:
+        st = cmd.try_compile(body % {"inline": kw}, None, None)
+        if st:
+            return kw
+
+    return ""
+
+
+def check_gcc_function_attribute(cmd, attribute, name):
+    """Return True if the given function attribute is supported."""
+    cmd._check_compiler()
+    if is_gcc(cmd):
+        pragma = '#pragma GCC diagnostic error "-Wattributes"'
+    elif is_clang(cmd):
+        pragma = '#pragma clang diagnostic error "-Wattributes"'
+    else:
+        pragma = ""
+
+    body = (
+        textwrap.dedent(
+            """
+        %s
+
+        int %s %s(void*);
+
+        int main(void)
+        {
+            return 0;
+        }
+        """
+        )
+        % (pragma, attribute, name)
+    )
+    return cmd.try_compile(body, None, None) != 0
 
 
 def create_config_h(config):
     dirname = os.path.dirname(__file__)
-    config_h = os.path.join(dirname, 'bn_config.h')
+    config_h = os.path.join(dirname, "bn_config.h")
 
     if (
-        os.path.exists(config_h) and
-        os.stat(__file__).st_mtime < os.stat(config_h).st_mtime
+        os.path.exists(config_h)
+        and os.stat(__file__).st_mtime < os.stat(config_h).st_mtime
     ):
         return
 
@@ -26,6 +110,13 @@ def create_config_h(config):
         else:
             output.append((config_attr, "0"))
 
-    with open(config_h, 'w') as f:
+    inline_alias = check_inline(config)
+
+    with open(config_h, "w") as f:
         for setting in output:
             f.write("#define {} {}\n".format(*setting))
+
+        if inline_alias == "inline":
+            f.write("/* undef inline */\n")
+        else:
+            f.write("#define inline {}\n".format(inline_alias))

--- a/bottleneck/src/bottleneck.h
+++ b/bottleneck/src/bottleneck.h
@@ -45,18 +45,6 @@
 #define RUNTIME_ERR(text) PyErr_SetString(PyExc_RuntimeError, text)
 
 /* `inline` and `opt_3` copied from NumPy. */
-#if defined(_MSC_VER)
-        #define BN_INLINE __inline
-#elif defined(__GNUC__)
-	#if defined(__STRICT_ANSI__)
-		#define BN_INLINE __inline__
-	#else
-		#define BN_INLINE inline
-	#endif
-#else
-        #define BN_INLINE
-#endif
-
 #if HAVE_ATTRIBUTE_OPTIMIZE_OPT_3
     #define BN_OPT_3 __attribute__((optimize("O3")))
 #else
@@ -67,13 +55,13 @@
  * NAN and INFINITY like macros (same behavior as glibc for NAN, same as C99
  * for INFINITY). Copied from NumPy.
  */
-BN_INLINE static float __bn_inff(void)
+static inline float __bn_inff(void)
 {
     const union { npy_uint32 __i; float __f;} __bint = {0x7f800000UL};
     return __bint.__f;
 }
 
-BN_INLINE static float __bn_nanf(void)
+static inline float __bn_nanf(void)
 {
     const union { npy_uint32 __i; float __f;} __bint = {0x7fc00000UL};
     return __bint.__f;

--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -26,7 +26,7 @@ struct _iter {
 };
 typedef struct _iter iter;
 
-static BN_INLINE void
+static inline void
 init_iter_one(iter *it, PyArrayObject *a, int axis)
 {
     int i, j = 0;
@@ -68,7 +68,7 @@ init_iter_one(iter *it, PyArrayObject *a, int axis)
  * calling Py_DECREF(it.a_ravel) after you are done with the iterator.
  * See nanargmin for an example.
  */
-static BN_INLINE void
+static inline void
 init_iter_all(iter *it, PyArrayObject *a, int ravel, int anyorder)
 {
     int i, j = 0;
@@ -208,7 +208,7 @@ struct _iter2 {
 };
 typedef struct _iter2 iter2;
 
-static BN_INLINE void
+static inline void
 init_iter2(iter2 *it, PyArrayObject *a, PyObject *y, int axis)
 {
     int i, j = 0;
@@ -285,7 +285,7 @@ struct _iter3 {
 };
 typedef struct _iter3 iter3;
 
-static BN_INLINE void
+static inline void
 init_iter3(iter3 *it, PyArrayObject *a, PyObject *y, PyObject *z, int axis)
 {
     int i, j = 0;

--- a/bottleneck/src/move_median/move_median.c
+++ b/bottleneck/src/move_median/move_median.c
@@ -26,24 +26,24 @@ idx1       = idx2
 */
 
 /* helper functions */
-static MM_INLINE ai_t mm_get_median(mm_handle *mm);
-static MM_INLINE void heapify_small_node(mm_handle *mm, idx_t idx);
-static MM_INLINE void heapify_large_node(mm_handle *mm, idx_t idx);
-static MM_INLINE idx_t mm_get_smallest_child(mm_node **heap, idx_t window,
+static inline ai_t mm_get_median(mm_handle *mm);
+static inline void heapify_small_node(mm_handle *mm, idx_t idx);
+static inline void heapify_large_node(mm_handle *mm, idx_t idx);
+static inline idx_t mm_get_smallest_child(mm_node **heap, idx_t window,
                                              idx_t idx, mm_node **child);
-static MM_INLINE idx_t mm_get_largest_child(mm_node **heap, idx_t window,
+static inline idx_t mm_get_largest_child(mm_node **heap, idx_t window,
                                             idx_t idx, mm_node **child);
-static MM_INLINE void mm_move_up_small(mm_node **heap, idx_t idx,
+static inline void mm_move_up_small(mm_node **heap, idx_t idx,
                                        mm_node *node, idx_t p_idx,
                                        mm_node *parent);
-static MM_INLINE void mm_move_down_small(mm_node **heap, idx_t window,
+static inline void mm_move_down_small(mm_node **heap, idx_t window,
                                          idx_t idx, mm_node *node);
-static MM_INLINE void mm_move_down_large(mm_node **heap, idx_t idx,
+static inline void mm_move_down_large(mm_node **heap, idx_t idx,
                                          mm_node *node, idx_t p_idx,
                                          mm_node *parent);
-static MM_INLINE void mm_move_up_large(mm_node **heap, idx_t window, idx_t idx,
+static inline void mm_move_up_large(mm_node **heap, idx_t window, idx_t idx,
                                        mm_node *node);
-static MM_INLINE void mm_swap_heap_heads(mm_node **s_heap, idx_t n_s,
+static inline void mm_swap_heap_heads(mm_node **s_heap, idx_t n_s,
                                          mm_node **l_heap, idx_t n_l,
                                          mm_node *s_node, mm_node *l_node);
 
@@ -516,7 +516,7 @@ mm_free(mm_handle *mm)
 */
 
 /* Return the current median */
-static MM_INLINE ai_t
+static inline ai_t
 mm_get_median(mm_handle *mm)
 {
     idx_t n_total = mm->n_l + mm->n_s;
@@ -528,7 +528,7 @@ mm_get_median(mm_handle *mm)
 }
 
 
-static MM_INLINE void
+static inline void
 heapify_small_node(mm_handle *mm, idx_t idx)
 {
     idx_t idx2;
@@ -580,7 +580,7 @@ heapify_small_node(mm_handle *mm, idx_t idx)
 }
 
 
-static MM_INLINE void
+static inline void
 heapify_large_node(mm_handle *mm, idx_t idx)
 {
     idx_t idx2;
@@ -635,7 +635,7 @@ heapify_large_node(mm_handle *mm, idx_t idx)
 
 /* Return the index of the smallest child of the node. The pointer
  * child will also be set. */
-static MM_INLINE idx_t
+static inline idx_t
 mm_get_smallest_child(mm_node **heap, idx_t window, idx_t idx, mm_node **child)
 {
     idx_t i0 = FC_IDX(idx);
@@ -660,7 +660,7 @@ mm_get_smallest_child(mm_node **heap, idx_t window, idx_t idx, mm_node **child)
 
 /* Return the index of the largest child of the node. The pointer
  * child will also be set. */
-static MM_INLINE idx_t
+static inline idx_t
 mm_get_largest_child(mm_node **heap, idx_t window, idx_t idx, mm_node **child)
 {
     idx_t i0 = FC_IDX(idx);
@@ -684,7 +684,7 @@ mm_get_largest_child(mm_node **heap, idx_t window, idx_t idx, mm_node **child)
 
 
 /* Move the given node up through the heap to the appropriate position. */
-static MM_INLINE void
+static inline void
 mm_move_up_small(mm_node **heap, idx_t idx, mm_node *node, idx_t p_idx,
                  mm_node *parent)
 {
@@ -700,7 +700,7 @@ mm_move_up_small(mm_node **heap, idx_t idx, mm_node *node, idx_t p_idx,
 
 
 /* Move the given node down through the heap to the appropriate position. */
-static MM_INLINE void
+static inline void
 mm_move_down_small(mm_node **heap, idx_t window, idx_t idx, mm_node *node)
 {
     mm_node *child;
@@ -715,7 +715,7 @@ mm_move_down_small(mm_node **heap, idx_t window, idx_t idx, mm_node *node)
 
 
 /* Move the given node down through the heap to the appropriate position. */
-static MM_INLINE void
+static inline void
 mm_move_down_large(mm_node **heap, idx_t idx, mm_node *node, idx_t p_idx,
                    mm_node *parent)
 {
@@ -731,7 +731,7 @@ mm_move_down_large(mm_node **heap, idx_t idx, mm_node *node, idx_t p_idx,
 
 
 /* Move the given node up through the heap to the appropriate position. */
-static MM_INLINE void
+static inline void
 mm_move_up_large(mm_node **heap, idx_t window, idx_t idx, mm_node *node)
 {
     mm_node *child;
@@ -746,7 +746,7 @@ mm_move_up_large(mm_node **heap, idx_t window, idx_t idx, mm_node *node)
 
 
 /* Swap the heap heads. */
-static MM_INLINE void
+static inline void
 mm_swap_heap_heads(mm_node **s_heap, idx_t n_s, mm_node **l_heap, idx_t n_l,
                    mm_node *s_node, mm_node *l_node)
 {

--- a/bottleneck/src/move_median/move_median.h
+++ b/bottleneck/src/move_median/move_median.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
+#include <bn_config.h>
 
 typedef size_t idx_t;
 typedef double ai_t;
@@ -69,24 +70,11 @@ void mm_free(mm_handle *mm);
 
 /* Copied from Cython ---------------------------------------------------- */
 
-/* inline attribute */
-#ifndef MM_INLINE
-    #if defined(__GNUC__)
-      #define MM_INLINE __inline__
-    #elif defined(_MSC_VER)
-      #define MM_INLINE __inline
-    #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-      #define MM_INLINE inline
-    #else
-      #define MM_INLINE
-    #endif
-#endif
-
 /* NaN */
 #ifdef NAN
     #define MM_NAN() ((float) NAN)
 #else
-    static MM_INLINE float MM_NAN(void) {
+    static inline float MM_NAN(void) {
         float value;
         memset(&value, 0xFF, sizeof(value));
         return value;

--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -779,7 +779,7 @@ intern_strings(void) {
 
 /* mover ----------------------------------------------------------------- */
 
-static BN_INLINE int
+static inline int
 parse_args(PyObject *args,
            PyObject *kwds,
            int has_ddof,

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -414,7 +414,7 @@ intern_strings(void) {
 
 /* nonreducer_axis ------------------------------------------------------- */
 
-static BN_INLINE int
+static inline int
 parse_partition(PyObject *args,
                 PyObject *kwds,
                 PyObject **a,
@@ -487,7 +487,7 @@ parse_partition(PyObject *args,
 
 }
 
-static BN_INLINE int
+static inline int
 parse_rankdata(PyObject *args,
                PyObject *kwds,
                PyObject **a,
@@ -550,7 +550,7 @@ parse_rankdata(PyObject *args,
 
 }
 
-static BN_INLINE int
+static inline int
 parse_push(PyObject *args,
            PyObject *kwds,
            PyObject **a,

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -116,7 +116,7 @@ intern_strings(void) {
 
 /* nonreduce ------------------------------------------------------------- */
 
-static BN_INLINE int
+static inline int
 parse_args(PyObject *args,
            PyObject *kwds,
            PyObject **a,

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1117,7 +1117,7 @@ intern_strings(void) {
 
 /* reducer --------------------------------------------------------------- */
 
-static BN_INLINE int
+static inline int
 parse_args(PyObject *args,
            PyObject *kwds,
            int has_ddof,

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,9 @@ def prepare_modules():
     ext += [Extension("bottleneck.move",
                       sources=["bottleneck/src/move.c",
                                "bottleneck/src/move_median/move_median.c"],
-                      depends=base_includes,
+                      depends=base_includes + [
+                          "bottleneck/src/move_median/move_median.h"
+                      ],
                       extra_compile_args=['-O2'])]
     ext += [Extension("bottleneck.nonreduce",
                       sources=["bottleneck/src/nonreduce.c"],


### PR DESCRIPTION
We had previously copied numpy's `inline` logic for _two_ separate variables `BN_INLINE` and `MM_INLINE`. This PR proposes eliminating both in favor of another numpy approach: `#define inline`

To do this, we pull in more of numpy's compiler feature detection code, with some cleanup so successful tests don't throw off tons of warnings due to bad syntax.

Also, declare an unspecified dependency in `setup.py` that was surfaced by this cleanup.