### PR TITLE
DOC: provide relevant info on how to fix numpy version skew if encountered

### DIFF
--- a/bottleneck/__init__.py
+++ b/bottleneck/__init__.py
@@ -1,14 +1,21 @@
-from .reduce import (nansum, nanmean, nanstd, nanvar, nanmin, nanmax,
-                     median, nanmedian, ss, nanargmin, nanargmax, anynan,
-                     allnan)
-from .nonreduce import replace
-from .nonreduce_axis import (partition, argpartition, rankdata, nanrankdata,
-                             push)
-from .move import (move_sum, move_mean, move_std, move_var, move_min,
-                   move_max, move_argmin, move_argmax, move_median,
-                   move_rank)
+try:
+    from .reduce import (nansum, nanmean, nanstd, nanvar, nanmin, nanmax,
+                         median, nanmedian, ss, nanargmin, nanargmax, anynan,
+                         allnan)
+    from .nonreduce import replace
+    from .nonreduce_axis import (partition, argpartition, rankdata, nanrankdata,
+                                 push)
+    from .move import (move_sum, move_mean, move_std, move_var, move_min,
+                       move_max, move_argmin, move_argmax, move_median,
+                       move_rank)
 
-from . import slow
+    from . import slow
+except ImportError:
+    raise ImportError("bottleneck modules failed to import, likely due to a "
+                      "mismatch in NumPy versions. Either upgrade numpy to "
+                      "1.16+ or install with:\n\t"
+                      "pip install --no-build-isolation --no-cache-dir "
+                      "bottleneck")
 
 from bottleneck.benchmark.bench import bench
 from bottleneck.benchmark.bench_detailed import bench_detailed


### PR DESCRIPTION
Not a full answer to the build-pinning question, but at least provide users a best guess as to how to resolve a numpy version conflict if encountered.

Thanks to @stas00 for documenting workarounds in #204 