### PR TITLE
BLD: pin numpy in pyproject.toml on a per-python-version basis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,13 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = [
+    "setuptools",
+    "wheel",
+    "numpy==1.13.3; python_version=='2.7' and platform_system!='AIX'",
+    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
+    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
+    "numpy==1.16.0; python_version=='2.7' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version>='3.7' and platform_system=='AIX'",
+]

--- a/tools/travis/conda_install.sh
+++ b/tools/travis/conda_install.sh
@@ -19,10 +19,12 @@ conda create -q -n "${TEST_NAME}" "${TEST_DEPS[@]}" python="${PYTHON_VERSION}"
 set +v # we dont want to see commands in the conda script
 
 source activate "${TEST_NAME}"
+conda update pip
 conda info -a
 conda list
 
 if [ -n "${PIP_DEPS}" ]; then
+    pip install --upgrade pip
     # Install numpy via pip for python=3.5 and numpy=1.16
     pip install ${PIP_DEPS}
 fi


### PR DESCRIPTION
Match how `scipy` and `pandas` are handling the `numpy` pinning issue, including the AIX patch mentioned here: https://github.com/scipy/scipy/pull/10431

Pinning to an older version of numpy appears to work just fine with local testing, given the api is generally backwards compatible. This may change in a future release, which will require a new release from `bottleneck` - I'm fine with doing that as needed.