### PR TITLE
PERF: eliminate unnecessary ravel for median with order="F", speedup of up to 2x

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -11,6 +11,10 @@
     iter it; \
     init_iter_all(&it, a, 1, 0);
 
+#define INIT_ALL_RAVEL_ANY_ORDER \
+    iter it; \
+    init_iter_all(&it, a, 1, 1);
+
 /* used with INIT_ALL_RAVEL */
 #define DECREF_INIT_ALL_RAVEL \
     if (it.a_ravel != NULL) { \
@@ -827,11 +831,12 @@ REDUCE_MAIN(ss, 0)
 /* repeat = {'NAME': ['median', 'nanmedian'],
              'FUNC': ['MEDIAN', 'NANMEDIAN']} */
 /* dtype = [['float64', 'float64'], ['float32', 'float32']] */
+
 REDUCE_ALL(NAME, DTYPE0)
 {
     npy_intp i;
     npy_DTYPE1 med;
-    INIT_ALL_RAVEL
+    INIT_ALL_RAVEL_ANY_ORDER
     BN_BEGIN_ALLOW_THREADS
     BUFFER_NEW(DTYPE0, LENGTH)
     if (LENGTH == 0) {
@@ -842,7 +847,6 @@ REDUCE_ALL(NAME, DTYPE0)
     done:
     BUFFER_DELETE
     BN_END_ALLOW_THREADS
-    DECREF_INIT_ALL_RAVEL
     return PyFloat_FromDouble(med);
 }
 
@@ -875,7 +879,7 @@ REDUCE_ALL(median, DTYPE0)
 {
     npy_intp i;
     npy_DTYPE1 med;
-    INIT_ALL_RAVEL
+    INIT_ALL_RAVEL_ANY_ORDER
     BN_BEGIN_ALLOW_THREADS
     if (LENGTH == 0) {
         med = BN_NAN;
@@ -885,7 +889,6 @@ REDUCE_ALL(median, DTYPE0)
         BUFFER_DELETE
     }
     BN_END_ALLOW_THREADS
-    DECREF_INIT_ALL_RAVEL
     return PyFloat_FromDouble(med);
 }
 


### PR DESCRIPTION
When computing `bn.median(arr, axis=None)` for `arr = np.array(..., order='F')` we currently call `np.ravel()`, which copies the data into C-order. Since `axis=None`, we're computing the median for all of the data and C-ordering therefore does not matter.

Eliminating the superfluous copy gives up to a 2x speedup:
```
       before           after         ratio
     [7ff5451a]       [9b20723c]
     <no_ravel_median~1>       <no_ravel_median>
-     5.20±0.08ms       4.70±0.1ms     0.90  reduce.Time2DReductions.time_median('int64', (1000, 1000), 'C', 1) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      6.74±0.1ms      6.07±0.08ms     0.90  reduce.Time2DReductions.time_nanmedian('int64', (1000, 1000), 'C', 0) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-     12.1±0.04ms       10.4±0.2ms     0.86  reduce.Time2DReductions.time_nanmedian('float32', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-     12.2±0.03ms      10.4±0.04ms     0.85  reduce.Time2DReductions.time_median('float32', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      5.75±0.3ms       4.41±0.1ms     0.77  reduce.Time2DReductions.time_median('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      5.13±0.3ms      3.85±0.05ms     0.75  reduce.Time2DReductions.time_median('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      15.1±0.2ms      11.3±0.05ms     0.75  reduce.Time2DReductions.time_median('float64', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      15.1±0.2ms       11.2±0.2ms     0.74  reduce.Time2DReductions.time_median('float64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      5.20±0.3ms      3.84±0.04ms     0.74  reduce.Time2DReductions.time_nanmedian('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      15.6±0.2ms       11.4±0.1ms     0.73  reduce.Time2DReductions.time_nanmedian('float64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      6.05±0.3ms      4.40±0.03ms     0.73  reduce.Time2DReductions.time_nanmedian('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      15.3±0.2ms       11.1±0.1ms     0.72  reduce.Time2DReductions.time_nanmedian('float64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      15.4±0.2ms       11.1±0.2ms     0.72  reduce.Time2DReductions.time_nanmedian('float64', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      15.7±0.1ms       11.2±0.1ms     0.71  reduce.Time2DReductions.time_median('float64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      6.52±0.1ms       4.44±0.1ms     0.68  reduce.Time2DReductions.time_median('int32', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      6.45±0.3ms      4.38±0.04ms     0.68  reduce.Time2DReductions.time_nanmedian('int32', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      8.91±0.2ms       5.07±0.2ms     0.57  reduce.Time2DReductions.time_median('int64', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      8.88±0.2ms       5.05±0.1ms     0.57  reduce.Time2DReductions.time_nanmedian('int64', (1000, 1000), 'F', None) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
-      9.80±0.1ms       5.10±0.2ms     0.52  reduce.Time2DReductions.time_nanmedian('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      9.84±0.2ms       5.01±0.1ms     0.51  reduce.Time2DReductions.time_median('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      9.44±0.9ms      4.73±0.09ms     0.50  reduce.Time2DReductions.time_nanmedian('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        9.53±1ms      4.62±0.03ms     0.49  reduce.Time2DReductions.time_median('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
       before           after         ratio
     [7ff5451a]       [9b20723c]
     <no_ravel_median~1>       <no_ravel_median>
+     4.47±0.09μs      5.77±0.07μs     1.29  reduce.Time1DReductions.time_median('float64', (1000,)) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
+     3.38±0.09μs      3.84±0.03μs     1.14  reduce.Time1DReductions.time_nanmedian('float64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+     2.15±0.01μs      2.38±0.04μs     1.11  reduce.Time1DReductions.time_median('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+     5.26±0.07μs       5.79±0.1μs     1.10  reduce.Time1DReductions.time_nanmedian('float64', (1000,)) [T470/conda-py2.7-numpy1.16-CCgcc-CXXg++]
```