### PR TITLE
BLD: remove windows build from GitHub Actions as MSVC is not set up properly

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 12
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Seems the default image doesn't set up the appropriate MSVC install for use with python, remove for now