### PR TITLE
BENCH: add asv benchmarks for bn.move and bn.nonreduce_axis

### DIFF
--- a/asv_bench/benchmarks/move.py
+++ b/asv_bench/benchmarks/move.py
@@ -1,0 +1,88 @@
+import bottleneck as bn
+from .reduce import get_cached_rand_array
+
+
+class Time1DMove:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3,), (10 ** 5,), (10 ** 7,)],
+        [10],
+    ]
+    param_names = ["dtype", "shape", "window"]
+
+    def setup(self, dtype, shape, window):
+        self.arr = get_cached_rand_array(shape, dtype, "C")
+
+    def time_move_sum(self, dtype, shape, window):
+        bn.move_sum(self.arr, window)
+
+    def time_move_mean(self, dtype, shape, window):
+        bn.move_mean(self.arr, window)
+
+    def time_move_std(self, dtype, shape, window):
+        bn.move_std(self.arr, window)
+
+    def time_move_var(self, dtype, shape, window):
+        bn.move_var(self.arr, window)
+
+    def time_move_min(self, dtype, shape, window):
+        bn.move_min(self.arr, window)
+
+    def time_move_max(self, dtype, shape, window):
+        bn.move_max(self.arr, window)
+
+    def time_move_argmin(self, dtype, shape, window):
+        bn.move_argmin(self.arr, window)
+
+    def time_move_argmax(self, dtype, shape, window):
+        bn.move_argmax(self.arr, window)
+
+    def time_move_median(self, dtype, shape, window):
+        bn.move_median(self.arr, window)
+
+    def time_move_rank(self, dtype, shape, window):
+        bn.move_rank(self.arr, window)
+
+
+class Time2DMove:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3, 10 ** 3)],
+        ["C", "F"],
+        [0, 1],
+        [10],
+    ]
+    param_names = ["dtype", "shape", "order", "axis", "window"]
+
+    def setup(self, dtype, shape, order, axis, window):
+        self.arr = get_cached_rand_array(shape, dtype, order)
+
+    def time_move_sum(self, dtype, shape, order, axis, window):
+        bn.move_sum(self.arr, window, axis=axis)
+
+    def time_move_mean(self, dtype, shape, order, axis, window):
+        bn.move_mean(self.arr, window, axis=axis)
+
+    def time_move_std(self, dtype, shape, order, axis, window):
+        bn.move_std(self.arr, window, axis=axis)
+
+    def time_move_var(self, dtype, shape, order, axis, window):
+        bn.move_var(self.arr, window, axis=axis)
+
+    def time_move_min(self, dtype, shape, order, axis, window):
+        bn.move_min(self.arr, window, axis=axis)
+
+    def time_move_max(self, dtype, shape, order, axis, window):
+        bn.move_max(self.arr, window, axis=axis)
+
+    def time_move_argmin(self, dtype, shape, order, axis, window):
+        bn.move_argmin(self.arr, window, axis=axis)
+
+    def time_move_argmax(self, dtype, shape, order, axis, window):
+        bn.move_argmax(self.arr, window, axis=axis)
+
+    def time_move_median(self, dtype, shape, order, axis, window):
+        bn.move_median(self.arr, window, axis=axis)
+
+    def time_move_rank(self, dtype, shape, order, axis, window):
+        bn.move_rank(self.arr, window, axis=axis)

--- a/asv_bench/benchmarks/nonreduce_axis.py
+++ b/asv_bench/benchmarks/nonreduce_axis.py
@@ -1,0 +1,29 @@
+import bottleneck as bn
+from .reduce import get_cached_rand_array
+
+
+class Time1DNonreduceAxis:
+    params = [
+        ["int32", "int64", "float32", "float64"],
+        [(10 ** 3,), (10 ** 5,), (10 ** 7,)],
+    ]
+    param_names = ["dtype", "shape"]
+
+    def setup(self, dtype, shape):
+        self.arr = get_cached_rand_array(shape, dtype, "C")
+        self.half = shape[0] // 2
+
+    def time_partition(self, dtype, shape):
+        bn.partition(self.arr, self.half)
+
+    def time_argpartition(self, dtype, shape):
+        bn.argpartition(self.arr, self.half)
+
+    def time_rankdata(self, dtype, shape):
+        bn.rankdata(self.arr)
+
+    def time_nanrankdata(self, dtype, shape):
+        bn.nanrankdata(self.arr)
+
+    def time_push(self, dtype, shape):
+        bn.push(self.arr)


### PR DESCRIPTION
These are the last modules missing `asv` coverage - a comparison against `v1.2.0` shows no regressions