### PR TITLE
DOC: Add readthedocs.yml to help RTD build our docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+python:
+  setup_py_install: true


### PR DESCRIPTION
RTD doesn't attempt `python setup.py build` prior to building docs, so attempt to force that here.