### PR TITLE
Do not include bn_config.h in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ exclude bottleneck/src/reduce.c
 exclude bottleneck/src/move.c
 exclude bottleneck/src/nonreduce.c
 exclude bottleneck/src/nonreduce_axis.c
+exclude bottleneck/src/bn_config.h
 
 recursive-include doc *
 recursive-exclude doc/build *


### PR DESCRIPTION
Fix compile errors when building Bottleneck-1.3.0rc1 with msvc on Windows using the source distribution on PyPI:
```
bottleneck/src/reduce.c(2388): error C2143: syntax error: missing ')' before '('
bottleneck/src/reduce.c(2388): error C2091: function returns function
bottleneck/src/reduce.c(2388): error C2143: syntax error: missing ')' before 'string'
bottleneck/src/reduce.c(2388): error C2143: syntax error: missing '{' before 'string'
bottleneck/src/reduce.c(2388): error C2059: syntax error: 'string'
...
```