### PR TITLE
BUG: fix memory leak in nanmedian with axis=None

### DIFF
--- a/asv_bench/benchmarks/memory.py
+++ b/asv_bench/benchmarks/memory.py
@@ -1,0 +1,9 @@
+import bottleneck as bn
+import numpy as np
+
+
+class Memory:
+    def peakmem_nanmedian(self):
+        arr = np.arange(1).reshape((1, 1))
+        for i in range(1000000):
+            bn.nanmedian(arr)

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -824,6 +824,7 @@ REDUCE_ALL(NAME, DTYPE0) {
     done:
     BUFFER_DELETE
     BN_END_ALLOW_THREADS
+    DECREF_INIT_ALL_RAVEL
     return PyFloat_FromDouble(med);
 }
 
@@ -864,6 +865,7 @@ REDUCE_ALL(median, DTYPE0) {
         BUFFER_DELETE
     }
     BN_END_ALLOW_THREADS
+    DECREF_INIT_ALL_RAVEL
     return PyFloat_FromDouble(med);
 }
 


### PR DESCRIPTION
Partial revert of #248, resolves #276.

`asv find` identified #248 as the cause of the regression:
```
·· Installing 2b9c661e <v1.3.0rc1~45> into conda-py3.6-numpy1.16-CCgcc-CXXg++
·· Benchmarking conda-py3.6-numpy1.16-CCgcc-CXXg++
··· memory.Memory.peakmem_nanmedian                                                                                                                                                           206M
· Greatest regression found: 2b9c661e <v1.3.0rc1~45>
```

The issue occurs when invoking `nanmedian` with `axis=None` (the default) and results in a memory leak. The fix results in constant memory usage.