### PR TITLE
PERF: Median speedups

### DIFF
--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -368,7 +368,8 @@ init_iter3(iter3 *it, PyArrayObject *a, PyObject *y, PyObject *z, int axis)
 #define  AX(dtype, x)   *(npy_##dtype *)(it.pa + (x) * it.astride)
 #define  AOLD(dtype)    *(npy_##dtype *)(it.pa + (it.i - window) * it.astride)
 
-#define  SI(pa)         pa[it.i * it.stride]    
+#define  SI(pa)         pa[it.i * it.stride]
+#define  SX(pa, x)      pa[x * it.stride]
 
 #define  YPP            *py++
 #define  YI(dtype)      *(npy_##dtype *)(it.py + it.i++ * it.ystride)

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -771,8 +771,15 @@ REDUCE_MAIN(ss, 0)
 #define MEDIAN_INT(dtype) \
     npy_intp j, l, r, k; \
     npy_##dtype ai; \
-    for (i = 0; i < LENGTH; i++) { \
-        B(dtype, i) = AX(dtype, i); \
+    const npy_##dtype* pa = PA(dtype); \
+    if (it.stride == 1) { \
+        for (i = 0; i < LENGTH; i++) { \
+            B(dtype, i) = pa[i]; \
+        } \
+    } else { \
+        for (i = 0; i < LENGTH; i++) { \
+            B(dtype, i) = SX(pa, i); \
+        } \
     } \
     k = LENGTH >> 1; \
     l = 0; \
@@ -854,6 +861,7 @@ REDUCE_ONE(NAME, DTYPE0) {
 /* repeat end */
 
 /* dtype = [['int64', 'float64'], ['int32', 'float64']] */
+BN_OPT_3
 REDUCE_ALL(median, DTYPE0) {
     npy_intp i;
     npy_DTYPE1 med;
@@ -871,6 +879,7 @@ REDUCE_ALL(median, DTYPE0) {
     return PyFloat_FromDouble(med);
 }
 
+BN_OPT_3
 REDUCE_ONE(median, DTYPE0) {
     npy_intp i;
     npy_DTYPE1 med;

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -824,14 +824,14 @@ REDUCE_ALL(NAME, DTYPE0) {
     npy_DTYPE1 med;
     INIT_ALL_RAVEL_ANY_ORDER
     BN_BEGIN_ALLOW_THREADS
-    BUFFER_NEW(DTYPE0, LENGTH)
     if (LENGTH == 0) {
         med = BN_NAN;
     } else {
+        BUFFER_NEW(DTYPE0, LENGTH)
         FUNC(DTYPE0)
+        done:
+        BUFFER_DELETE
     }
-    done:
-    BUFFER_DELETE
     BN_END_ALLOW_THREADS
     DECREF_INIT_ALL_RAVEL
     return PyFloat_FromDouble(med);

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -754,7 +754,9 @@ REDUCE_MAIN(ss, 0)
         ai = AX(dtype, i); \
         if (ai == ai) { \
             B(dtype, l++) = ai; \
-        } \
+        } else { \
+            break; \
+        }\
     } \
     if (l != LENGTH) { \
         med = BN_NAN; \


### PR DESCRIPTION
A couple speedups:
 - `bn.median()` buffer creation now early exits even sooner if a `np.NaN` is encountered.
 - 'bn.median()` buffer creation is now vectorized for integer inputs