### PR TITLE
PERF: Improve performance of nanmin/nanmax for axis=None

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -413,13 +413,15 @@ REDUCE_MAIN(NAME, 1)
 /* nanmin, nanmax -------------------------------------------------------- */
 
 /* repeat = {'NAME':      ['nanmin',         'nanmax'],
+             'INTCOMP':   ['<',              '>'],
              'COMPARE':   ['<=',             '>='],
              'BIG_FLOAT': ['BN_INFINITY',    '-BN_INFINITY'],
              'BIG_INT':   ['NPY_MAX_DTYPE0', 'NPY_MIN_DTYPE0']} */
 /* dtype = [['float64'], ['float32']] */
+BN_OPT_3
 REDUCE_ALL(NAME, DTYPE0) {
-    npy_DTYPE0 ai, extreme = BIG_FLOAT;
-    int allnan = 1;
+    npy_DTYPE0 extreme = BIG_FLOAT;
+    npy_bool allnan = 1;
     INIT_ALL
     if (SIZE == 0) {
         VALUE_ERR("numpy.NAME raises on a.size==0 and axis=None; "
@@ -427,17 +429,35 @@ REDUCE_ALL(NAME, DTYPE0) {
         return NULL;
     }
     BN_BEGIN_ALLOW_THREADS
-    WHILE {
-        FOR {
-            ai = AI(DTYPE0);
-            if (ai COMPARE extreme) {
-                extreme = ai;
-                allnan = 0;
+    const npy_DTYPE0* pa = PA(DTYPE0);
+    const npy_intp count = it.nits * it.length;
+    const npy_intp stride = it.stride;
+    if (it.stride == 1) {
+        for (npy_intp i=0; i < count; i++) {
+            if (allnan) {
+                if (pa[i] COMPARE extreme) {
+                    extreme = pa[i];
+                    allnan = 0;
+                }
+            } else {
+                extreme = pa[i] INTCOMP extreme ? pa[i] : extreme;
             }
         }
-        NEXT
+    } else {
+        for (npy_intp i=0; i < count; i++) {
+            if (allnan) {
+                if (pa[i * stride] COMPARE extreme) {
+                    extreme = pa[i * stride];
+                    allnan = 0;
+                }
+            } else {
+                extreme = pa[i * stride] INTCOMP extreme ? pa[i * stride] : extreme;
+            }
+        }
     }
-    if (allnan) extreme = BN_NAN;
+    if (allnan) {
+        extreme = BN_NAN;
+    }
     BN_END_ALLOW_THREADS
     return PyFloat_FromDouble(extreme);
 }
@@ -472,8 +492,9 @@ REDUCE_ONE(NAME, DTYPE0) {
 /* dtype end */
 
 /* dtype = [['int64'], ['int32']] */
+BN_OPT_3
 REDUCE_ALL(NAME, DTYPE0) {
-    npy_DTYPE0 ai, extreme = BIG_INT;
+    npy_DTYPE0 extreme = BIG_INT;
     INIT_ALL
     if (SIZE == 0) {
         VALUE_ERR("numpy.NAME raises on a.size==0 and axis=None; "
@@ -481,12 +502,16 @@ REDUCE_ALL(NAME, DTYPE0) {
         return NULL;
     }
     BN_BEGIN_ALLOW_THREADS
-    WHILE {
-        FOR {
-            ai = AI(DTYPE0);
-            if (ai COMPARE extreme) extreme = ai;
+    const npy_DTYPE0* pa = PA(DTYPE0);
+    const npy_intp count = it.nits * it.length;
+    if (it.stride == 1) {
+        for (npy_intp i=0; i<count; i++) {
+            extreme = pa[i] INTCOMP extreme ? pa[i] : extreme;
         }
-        NEXT
+    } else {
+        for (npy_intp i=0; i<count; i++) {
+            extreme = pa[i * it.stride] INTCOMP extreme ? pa[i * it.stride] : extreme;
+        }
     }
     BN_END_ALLOW_THREADS
     return PyLong_FromLongLong(extreme);

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -123,7 +123,11 @@ def unit_maker(func, decimal=5, skip_dtype=("nansum", "ss")):
                     msg = fmt2 % (name, name, traceback.format_exc())
                     err_msg += msg
                     assert False, err_msg
-                assert_array_almost_equal(actual, desired, decimal, err_msg)
+                try:
+                    assert_array_almost_equal(actual, desired, decimal, err_msg)
+                except AssertionError:
+                    print(a, axis, func(a, axis=axis), a.shape, a.flags, actual, desired)
+                    raise
                 err_msg += "\n dtype mismatch %s %s"
                 if name not in skip_dtype:
                     if hasattr(actual, "dtype") and hasattr(desired, "dtype"):


### PR DESCRIPTION
Improve `nanmin` and `nanmax` performance primarily for smaller dtypes (`int32`, `float32`)
```
$ asv compare upstream/master HEAD --only-changed -s --sort ratio
       before           after         ratio
     [70591905]       [36bcd6e8]
     <master~1>       <nanmin>  
-        892±20μs        697±200μs     0.78  reduce.Time2DReductions.time_nanmin('float32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.21±0.05μs         909±50ns     0.75  reduce.Time1DReductions.time_nanmin('float32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        892±40μs        626±200μs     0.70  reduce.Time2DReductions.time_nanmin('float32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        8.86±3ms         6.05±2ms     0.68  reduce.Time1DReductions.time_nanmin('float32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        87.8±3μs         59.1±3μs     0.67  reduce.Time1DReductions.time_nanmin('float32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        930±50ns         568±30ns     0.61  reduce.Time1DReductions.time_nanmin('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      5.95±0.4ms       2.85±0.2ms     0.48  reduce.Time1DReductions.time_nanmin('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        600±40μs         277±20μs     0.46  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        594±10μs         260±30μs     0.44  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        58.5±2μs       23.4±0.7μs     0.40  reduce.Time1DReductions.time_nanmin('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
```