### PR TITLE
DEPR: Adopt NEP 29, remove py2.7 and py3.5 from supported versions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest]
         exclude:
           - os: macOS-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,7 @@ git:
 jobs:
     fast_finish: true
     include:
-
-        # test installing bottleneck tarball before installing numpy;
-        # start this test first because it takes the longest
-        - os: linux
-          env: TEST_DEPS="numpy pytest hypothesis"
-               PYTHON_VERSION="2.7"
-               PYTHON_ARCH="64"
-               TEST_RUN="sdist"
-
-         # flake8 and black
+        # flake8 and black
         - os: linux
           env: TEST_DEPS="flake8 black"
                PYTHON_VERSION="3.7"
@@ -40,14 +31,6 @@ jobs:
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
                TEST_RUN="coverage"
-
-        # python 3.5
-        - os: linux
-          env: TEST_DEPS="pytest hypothesis"
-               PIP_DEPS="numpy>=1.16"
-               PYTHON_VERSION="3.5"
-               PYTHON_ARCH="64"
-               TEST_RUN="sdist"
 
          # python 3.6
         - os: linux
@@ -73,20 +56,6 @@ jobs:
                PYTHON_VERSION="3.8"
                PYTHON_ARCH="64"
                TEST_RUN="sdist"
-
-        # python 2.7
-        - os: osx
-          env: TEST_DEPS="numpy pytest hypothesis"
-               PYTHON_VERSION="2.7"
-               PYTHON_ARCH="64"
-               TEST_RUN="sdist"
-
-        # python 3.5
-        - os: osx
-          env: TEST_DEPS="pytest hypothesis"
-               PIP_DEPS="numpy>=1.16"
-               PYTHON_VERSION="3.5"
-               PYTHON_ARCH="64"
 
         # python 3.6
         - os: osx

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Install
 Requirements:
 
 ======================== ====================================================
-Bottleneck               Python 2.7, 3.5, 3.6, 3.7, 3.8; NumPy 1.16.0+
+Bottleneck               Python 3.6, 3.7, 3.8; NumPy 1.15.0+ (follows NEP 29)
 Compile                  gcc, clang, MinGW or MSVC
 Unit tests               pytest, hypothesis
 Documentation            sphinx, numpydoc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,30 +13,6 @@ environment:
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\tools\\appveyor\\windows_sdk.cmd"
 
     matrix:
-        - PYTHON_VERSION: "2.7"
-          PYTHON_ARCH: "32"
-          platform: x86
-          CONDA_HOME: "C:\\Miniconda"
-
-        - PYTHON_VERSION: "2.7"
-          PYTHON_ARCH: "64"
-          platform: x64
-          CONDA_HOME: "C:\\Miniconda-x64"
-
-        - PYTHON_VERSION: "3.5"
-          PYTHON_ARCH: "32"
-          DEPS: "pytest hypothesis"
-          PIP_DEPS: "numpy>=1.16"
-          platform: x86
-          CONDA_HOME: "C:\\Miniconda3"
-
-        - PYTHON_VERSION: "3.5"
-          PYTHON_ARCH: "64"
-          DEPS: "pytest hypothesis"
-          PIP_DEPS: "numpy>=1.16"
-          platform: x64
-          CONDA_HOME: "C:\\Miniconda3-x64"
-
         - PYTHON_VERSION: "3.6"
           PYTHON_ARCH: "32"
           platform: x86

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -55,7 +55,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7", "3.7"],
+    "pythons": ["3.7"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,6 @@ CLASSIFIERS = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
As I have received no objections on the mailing list or in #287, adopt and implement NEP 29 (https://numpy.org/neps/nep-0029-deprecation_policy.html)