### PR TITLE
Fix bug in replace on views with strides different than underlying array

### DIFF
--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -385,4 +385,13 @@ init_iter3(iter3 *it, PyArrayObject *a, PyObject *y, PyObject *z, int axis) {
         YPP = value; \
     }
 
+#define REDUCE_CONTIGUOUS (it.stride == 1 && ((it.ndim_m2 < 0) || (C_CONTIGUOUS(a) || F_CONTIGUOUS(a))))
+
+#define REDUCE_SPECIALIZE(code) { \
+    if (REDUCE_CONTIGUOUS) { \
+        code \
+    } else { \
+        code \
+    }
+
 #endif  // ITERATORS_H_

--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -387,7 +387,7 @@ init_iter3(iter3 *it, PyArrayObject *a, PyObject *y, PyObject *z, int axis) {
 
 #define REDUCE_CONTIGUOUS (it.stride == 1 && ((it.ndim_m2 < 0) || (C_CONTIGUOUS(a) || F_CONTIGUOUS(a))))
 
-#define REDUCE_SPECIALIZE(code) { \
+#define REDUCE_SPECIALIZE(code) \
     if (REDUCE_CONTIGUOUS) { \
         code \
     } else { \

--- a/bottleneck/tests/nonreduce_test.py
+++ b/bottleneck/tests/nonreduce_test.py
@@ -136,3 +136,13 @@ def test_replace_newaxis(dtype):
     array = np.ones((2, 2), dtype=dtype)[..., np.newaxis]
     result = bn.replace(array, 1, 2)
     assert (result == 2).all().all()
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_replace_view(dtype):
+    array = np.arange(20, dtype=dtype)
+    view = array[::2]
+
+    bn.replace(view, 5, -1)
+    assert view.min() == 0
+    assert array.min() == 0


### PR DESCRIPTION
Fix and test an issue with `bn.replace(arr[::2], ...)` style calls.