### PR TITLE
PERF: improve performance of nansum for integers

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -122,13 +122,28 @@ REDUCE_ONE(nansum, DTYPE0) {
 /* dtype end */
 
 /* dtype = [['int64'], ['int32']] */
+BN_OPT_3
 REDUCE_ALL(nansum, DTYPE0) {
     npy_DTYPE0 asum = 0;
     INIT_ALL
     BN_BEGIN_ALLOW_THREADS
-    WHILE {
-        FOR asum += AI(DTYPE0);
-        NEXT
+    if (REDUCE_CONTIGUOUS) {
+        npy_DTYPE0* pa = PA(DTYPE0);
+        const npy_intp nits = it.nits;
+        const npy_intp length = it.length;
+        for (npy_intp i=0; i < nits; i++) {
+            for (npy_intp j=0; j < length; j++) {
+                asum += pa[i * length + j];
+            }
+        }
+    } else {
+        WHILE {
+            npy_DTYPE0* pa = PA(DTYPE0);
+            FOR {
+                asum += pa[it.i * it.stride];
+            }
+            NEXT
+        }
     }
     BN_END_ALLOW_THREADS
     return PyLong_FromLongLong(asum);


### PR DESCRIPTION
Improve performance of `bn.nansum` for `int64/int32` in reduction operations.

```
$ asv compare HEAD^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [23332ea7]       [d6f40cff]
     <nansum_faster~1>       <nansum_faster>
-      5.71±0.1ms       5.04±0.1ms     0.88  reduce.Time1DReductions.time_nansum('int64', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         508±6μs          411±7μs     0.81  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         512±5μs         414±20μs     0.81  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     3.22±0.04ms      2.53±0.03ms     0.78  reduce.Time1DReductions.time_nansum('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        565±20μs          434±6μs     0.77  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        565±10μs          433±8μs     0.77  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        820±10ns          627±3ns     0.77  reduce.Time1DReductions.time_nansum('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         635±9ns         404±20ns     0.64  reduce.Time1DReductions.time_nansum('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        46.9±1μs      29.7±0.07μs     0.63  reduce.Time1DReductions.time_nansum('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        745±30ns          423±2ns     0.57  reduce.Time1DReductions.time_nansum('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         836±9ns         455±20ns     0.54  reduce.Time1DReductions.time_nansum('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         310±3μs         165±30μs     0.53  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     5.16±0.06ms      2.52±0.05ms     0.49  reduce.Time1DReductions.time_nansum('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      40.2±0.9μs      18.8±0.05μs     0.47  reduce.Time1DReductions.time_nansum('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         310±3μs          136±1μs     0.44  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      29.6±0.2μs       9.84±0.2μs     0.33  reduce.Time1DReductions.time_nansum('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-         512±4μs          155±5μs     0.30  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         512±4μs          153±2μs     0.30  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      50.1±0.2μs       11.6±0.3μs     0.23  reduce.Time1DReductions.time_nansum('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
```