### PR TITLE
Improvements to bn.bench()

### DIFF
--- a/bottleneck/benchmark/bench.py
+++ b/bottleneck/benchmark/bench.py
@@ -8,9 +8,16 @@ ARRAY_CACHE = {}
 
 
 def bench(
-    shapes=[(100,), (1000, 1000), (1000, 1000), (1000, 1000), (1000, 1000)],
-    axes=[0, 0, 0, 1, 1],
-    nans=[False, False, True, False, True],
+    shapes=[
+        (100,),
+        (1000, 1000),
+        (1000, 1000),
+        (1000, 1000),
+        (1000, 1000),
+        (1000, 1000),
+    ],
+    axes=[0, None, 0, 0, 1, 1],
+    nans=[False, True, False, True, False, True],
     dtype="float64",
     order="C",
     functions=None,


### PR DESCRIPTION
A few separate improvements to the `bn.bench()` function:
 * Speed up bulk testing by caching input arrays
 * Add fast/slow cases to `anynan`/`allnan`
 * Add `axis=None` case to default runs
