### PR TITLE
TST: re-enable nonreduce_axis argument exception tests

### DIFF
--- a/bottleneck/tests/nonreduce_axis_test.py
+++ b/bottleneck/tests/nonreduce_axis_test.py
@@ -178,6 +178,12 @@ def test_arg_parsing(func):
     else:
         fmt = "``%s` is an unknown nonreduce_axis function"
         raise ValueError(fmt % name)
+
+
+@pytest.mark.parametrize(
+    "func", bn.get_functions("nonreduce_axis"), ids=lambda x: x.__name__
+)
+def test_arg_raises(func):
     return unit_maker_raises(func)
 
 


### PR DESCRIPTION
These tests were inadvertently disabled as part of the switch from nose to pytest; re-enable them now.