### PR TITLE
TST: use Github Actions for Windows runs as well as OSX with 3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,10 +9,7 @@ jobs:
       max-parallel: 12
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macOS-latest]
-        exclude:
-          - os: macOS-latest
-            python-version: 3.8
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,6 +20,30 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v1
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
+    - uses: actions/cache@v1
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/bottleneck/tests/test_template.py
+++ b/bottleneck/tests/test_template.py
@@ -3,7 +3,7 @@ import os
 
 
 def test_make_c_files():
-    dirpath = os.path.join(os.path.dirname(__file__), "data/template_test")
+    dirpath = os.path.join(os.path.dirname(__file__), "data/template_test/")
     modules = ["test"]
     test_input = os.path.join(dirpath, "test.c")
     if os.path.exists(test_input):
@@ -16,7 +16,7 @@ def test_make_c_files():
 
     with open(os.path.join(dirpath, "test.c")) as f:
         test = f.read()
-    test = test.replace(dirpath, "{DIRPATH}")
+    test = test.replace(dirpath, "{DIRPATH}/")
 
     assert truth == test
 


### PR DESCRIPTION
Now that py2.7 and py3.5 have been dropped, we can (hopefully) use Github Actions to run the test suite on windows.

Separately, turn on py3.8 tests on OSX now that it is available.