### PR TITLE
PERF: do nanargmin/max in-order for integer dtypes

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -604,6 +604,7 @@ REDUCE_MAIN(NAME, 0)
 
 /* repeat = {'NAME':      ['nanargmin',      'nanargmax'],
              'COMPARE':   ['<=',             '>='],
+             'INTCOMP':   ['<',              '>'],
              'BIG_FLOAT': ['BN_INFINITY',    '-BN_INFINITY'],
              'BIG_INT':   ['NPY_MAX_DTYPE0', 'NPY_MIN_DTYPE0']} */
 /* dtype = [['float64'], ['float32']] */
@@ -676,6 +677,7 @@ REDUCE_ONE(NAME, DTYPE0) {
 /* dtype end */
 
 /* dtype = [['int64', 'intp'], ['int32', 'intp']] */
+BN_OPT_3
 REDUCE_ALL(NAME, DTYPE0) {
     npy_DTYPE1 idx = 0;
     npy_DTYPE0 ai, extreme = BIG_INT;
@@ -687,9 +689,10 @@ REDUCE_ALL(NAME, DTYPE0) {
         return NULL;
     }
     BN_BEGIN_ALLOW_THREADS
-    FOR_REVERSE {
-        ai = AI(DTYPE0);
-        if (ai COMPARE extreme) {
+    const npy_DTYPE0* pa = PA(DTYPE0);
+    FOR {
+        ai = SI(pa);
+        if (ai INTCOMP extreme) {
             extreme = ai;
             idx = INDEX;
         }
@@ -699,6 +702,7 @@ REDUCE_ALL(NAME, DTYPE0) {
     return PyLong_FromLongLong(idx);
 }
 
+BN_OPT_3
 REDUCE_ONE(NAME, DTYPE0) {
     npy_DTYPE1 idx = 0;
     npy_DTYPE0 ai, extreme;
@@ -711,9 +715,10 @@ REDUCE_ONE(NAME, DTYPE0) {
     BN_BEGIN_ALLOW_THREADS
     WHILE {
         extreme = BIG_INT;
-        FOR_REVERSE {
-            ai = AI(DTYPE0);
-            if (ai COMPARE extreme) {
+        const npy_DTYPE0* pa = PA(DTYPE0);
+        FOR {
+            ai = SI(pa);
+            if (ai INTCOMP extreme) {
                 extreme = ai;
                 idx = INDEX;
             }


### PR DESCRIPTION
Add some additional typing and do loop forward rather than reverse
```
$ asv compare upstream/master HEAD -s --sort ratio --only-changed
       before           after         ratio
     [595cdfd1]       [56337059]
     <actions>        <nanarg_ints>
-       98.7±10μs       89.6±0.8μs     0.91  reduce.Time1DReductions.time_nanargmax('float64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.09±0.3μs         987±10ns     0.91  reduce.Time1DReductions.time_nanargmin('float64', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        252±20μs          228±1μs     0.90  reduce.Time1DReductions.time_nanargmax('float64', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.03±0.04μs         926±20ns     0.90  reduce.Time1DReductions.time_nanargmin('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        68.5±4μs       61.0±0.5μs     0.89  reduce.Time1DReductions.time_nanargmax('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.20±0.3ms      1.95±0.03ms     0.89  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.08±0.05μs         959±10ns     0.88  reduce.Time1DReductions.time_nanargmax('float32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.07±0.4μs         934±20ns     0.87  reduce.Time1DReductions.time_nanargmin('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.07±0.06μs         935±30ns     0.87  reduce.Time1DReductions.time_nanargmax('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.31±0.1ms      1.14±0.02ms     0.87  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        103±10μs       89.1±0.9μs     0.87  reduce.Time1DReductions.time_nanargmin('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      4.48±0.4ms       3.80±0.2ms     0.85  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        72.0±4μs         61.1±1μs     0.85  reduce.Time1DReductions.time_nanargmin('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      3.16±0.3μs      2.66±0.07μs     0.84  reduce.Time1DReductions.time_nanargmin('float64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.49±0.3ms       2.05±0.2ms     0.82  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         110±5μs         89.9±1μs     0.82  reduce.Time1DReductions.time_nanargmin('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.24±0.2ms         990±10μs     0.80  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.54±0.09μs      1.21±0.01μs     0.79  reduce.Time1DReductions.time_nanargmax('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        907±80μs         712±10μs     0.78  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        10.2±2ms       7.88±0.3ms     0.78  reduce.Time1DReductions.time_nanargmin('int64', (10000000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.10±0.1ms         845±20μs     0.77  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.59±0.07ms      1.20±0.02ms     0.76  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        9.20±1ms       6.96±0.2ms     0.76  reduce.Time1DReductions.time_nanargmax('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.66±0.08μs      1.25±0.02μs     0.75  reduce.Time1DReductions.time_nanargmin('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      10.9±0.5ms       8.02±0.2ms     0.74  reduce.Time1DReductions.time_nanargmax('int64', (10000000,)) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.24±0.2ms         860±10μs     0.69  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.69±0.4ms      1.13±0.01ms     0.67  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.98±0.6ms      1.98±0.06ms     0.67  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.51±0.3ms        974±200μs     0.65  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.42±0.3ms          861±8μs     0.61  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      1.68±0.5ms          997±6μs     0.59  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.99±0.6ms      1.06±0.05ms     0.54  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.63±0.3ms         847±70μs     0.52  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.60±0.3ms      1.22±0.01ms     0.47  reduce.Time2DReductions.time_nanargmin('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.83±0.4ms         851±20μs     0.46  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.93±0.5ms         856±10μs     0.44  reduce.Time2DReductions.time_nanargmax('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      2.32±0.5ms         993±10μs     0.43  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      2.46±0.3ms      1.03±0.02ms     0.42  reduce.Time2DReductions.time_nanargmin('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
       before           after         ratio
     [595cdfd1]       [56337059]
     <actions>        <nanarg_ints>
+     1.23±0.04μs      1.38±0.06μs     1.13  reduce.Time1DReductions.time_nanargmax('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
```