### PR TITLE
PERF: speed up nanmin/max with non-null axis for int32

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -573,6 +573,7 @@ REDUCE_ALL(NAME, DTYPE0) {
     return PyLong_FromLongLong(extreme);
 }
 
+BN_OPT_3
 REDUCE_ONE(NAME, DTYPE0) {
     npy_DTYPE0 ai, extreme;
     INIT_ONE(DTYPE0, DTYPE0)
@@ -584,8 +585,9 @@ REDUCE_ONE(NAME, DTYPE0) {
     BN_BEGIN_ALLOW_THREADS
     WHILE {
         extreme = BIG_INT;
+        const npy_DTYPE0* pa = PA(DTYPE0);
         FOR {
-            ai = AI(DTYPE0);
+            ai = SI(pa);
             if (ai COMPARE extreme) extreme = ai;
         }
         YPP = extreme;


### PR DESCRIPTION
Up to 3x improvement, though certain combinations under clang see a slight slowdown.
```
$ asv compare HEAD^ HEAD -s --sort ratio --only-changed -f 1.1
       before           after         ratio
     [8106e742]       [45940427]
     <nanarg_ints>       <nanmin_speedup>
-        276±30μs          236±3μs     0.86  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        639±20μs         323±40μs     0.51  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        700±10μs         325±40μs     0.46  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        685±40μs         316±30μs     0.46  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         675±6μs         301±10μs     0.45  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        682±20μs          291±7μs     0.43  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        661±20μs          243±8μs     0.37  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-       682±100μs         247±30μs     0.36  reduce.Time2DReductions.time_nanmin('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-        676±70μs         242±20μs     0.36  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
       before           after         ratio
     [8106e742]       [45940427]
     <nanarg_ints>       <nanmin_speedup>
+        939±40μs      1.20±0.01ms     1.28  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+        858±10μs       1.00±0.1ms     1.17  reduce.Time2DReductions.time_nanmin('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+        842±10μs         969±10μs     1.15  reduce.Time2DReductions.time_nanmax('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
+         861±3μs         975±20μs     1.13  reduce.Time2DReductions.time_nanmin('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
```