### PR TITLE
Use oldest-supported-numpy in pyproject.toml and explicitly require Python 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,5 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy==1.13.3; python_version=='2.7' and platform_system!='AIX'",
-    "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
-    "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
-    "numpy==1.16.0; python_version=='2.7' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    "oldest-supported-numpy"
 ]

--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ metadata = dict(
     cmdclass=cmdclass,
     setup_requires=["numpy"],
     ext_modules=prepare_modules(),
+    python_requires=">=3.6",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Currently the pyproject.toml file is missing a Numpy version for Python 3.8. Rather than add this, I've switched this file to use the [oldest-supported-numpy](https://github.com/scipy/oldest-supported-numpy) meta-package which is equivalent to specifying all the environment markers (see the README for that project) but means that the pyproject.toml file here doesn't need to be updated in future when a new version of Python is released since this just requires a new release of oldest-supported-numpy.

It looks like bottleneck requires Python 3.6 based on the classifiers, so I've also added an explicit ``python_requires`` which will prevent older Python versions from downloading newer releases.