### PR TITLE
PERF: optimize for contiguous 2D nanmin/nanmax, speedups of up to 12x

### DIFF
--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -386,6 +386,8 @@ init_iter3(iter3 *it, PyArrayObject *a, PyObject *y, PyObject *z, int axis) {
     }
 
 #define REDUCE_CONTIGUOUS (it.stride == 1 && ((it.ndim_m2 < 0) || (C_CONTIGUOUS(a) || F_CONTIGUOUS(a))))
+#define ONE_CONTIGUOUS (it.stride == 1 && ((it.ndim_m2 >= 0) && ((C_CONTIGUOUS(a) || F_CONTIGUOUS(a)) && (it.axis == axis))))
+#define ONE_TRANSPOSE(dtype) ((it.ndim_m2 == 0) && it.astrides[it.ndim_m2] == sizeof(dtype) && ((C_CONTIGUOUS(a) && axis == 0) || (F_CONTIGUOUS(a) && axis == 1)))
 
 #define REDUCE_SPECIALIZE(code) \
     if (REDUCE_CONTIGUOUS) { \


### PR DESCRIPTION
Add specialized cases for contiguous 2D arrays in nanmin/max, which yield some solid speedups:
```
$ asv compare HEAD^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [37110cf7]       [5be4d6d4]
     <nanmin~1>       <nanmin>  
-     1.45±0.08ms         729±50μs     0.50  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.44±0.03ms         650±10μs     0.45  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-       829±200μs        357±100μs     0.43  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      2.25±0.1ms        899±100μs     0.40  reduce.Time2DReductions.time_nanmax('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.31±0.2ms         915±30μs     0.40  reduce.Time2DReductions.time_nanmax('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      2.13±0.1ms         751±20μs     0.35  reduce.Time2DReductions.time_nanmax('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      2.16±0.1ms         752±20μs     0.35  reduce.Time2DReductions.time_nanmax('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        843±30μs          290±7μs     0.34  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     2.56±0.02ms        777±100μs     0.30  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     2.07±0.07ms         587±30μs     0.28  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     2.56±0.02ms         709±30μs     0.28  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     2.10±0.09ms         572±20μs     0.27  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.11±0.1ms         281±10μs     0.25  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.13±0.1ms          268±6μs     0.24  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-      1.29±0.1ms         291±60μs     0.22  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.30±0.04ms         288±10μs     0.22  reduce.Time2DReductions.time_nanmax('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      3.49±0.1ms         587±20μs     0.17  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      3.57±0.2ms         589±10μs     0.16  reduce.Time2DReductions.time_nanmax('float64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.47±0.07ms         237±10μs     0.16  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.49±0.09ms          230±9μs     0.15  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     2.44±0.02ms          333±9μs     0.14  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     2.44±0.02ms          329±7μs     0.13  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-      3.03±0.2ms         265±40μs     0.09  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     3.03±0.09ms         231±20μs     0.08  reduce.Time2DReductions.time_nanmax('float32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
```