### PR TITLE
PERF: improve anynan reduction performance by up to 4x on float32

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1136,25 +1136,58 @@ nanmedian(PyObject *self, PyObject *args, PyObject *kwds) {
 /* anynan ---------------------------------------------------------------- */
 
 /* dtype = [['float64'], ['float32']] */
+BN_OPT_3
 REDUCE_ALL(anynan, DTYPE0) {
-    int f = 0;
-    npy_DTYPE0 ai;
+    npy_bool f = 0;
     INIT_ALL
     BN_BEGIN_ALLOW_THREADS
-    WHILE {
-        FOR {
-            ai = AI(DTYPE0);
-            if (ai != ai) {
-                f = 1;
-                goto done;
+    if (REDUCE_CONTIGUOUS) {
+        const npy_intp LOOP_SIZE = 512 / sizeof(npy_DTYPE0);
+        const npy_intp count = it.nits * it.length;
+        const npy_intp loop_count = count / LOOP_SIZE;
+        const npy_intp residual = count % LOOP_SIZE;
+        const npy_DTYPE0* pa = PA(DTYPE0);
+        npy_bool* f_arr = malloc(LOOP_SIZE * sizeof(npy_bool));
+        for (npy_intp j=0; j < LOOP_SIZE; j++) {
+            f_arr[j] = 0;
+        }
+
+        for (npy_intp i=0; (i < loop_count) && (f == 0); i++) {
+            for (npy_intp j=0; j < LOOP_SIZE; j++) {
+                f_arr[j] = isnan(pa[i * LOOP_SIZE + j]);
+            }
+
+            for (npy_intp j=0; j < LOOP_SIZE; j++) {
+                f += f_arr[j];
             }
         }
-        NEXT
+        for (npy_intp j=0; (j < residual) && (f == 0); j++) {
+            const npy_DTYPE0 ai = pa[loop_count * LOOP_SIZE + j];
+            if (ai != ai) {
+                f = 1;
+            }
+        }
+        free(f_arr);
+    } else {
+        WHILE {
+            const npy_DTYPE0* pa = PA(DTYPE0);
+            FOR {
+                const npy_DTYPE0 ai = pa[it.i * it.stride];
+                if (ai != ai) {
+                    f = 1;
+                    goto done;
+                }
+            }
+            NEXT
+        }
     }
     done:
     BN_END_ALLOW_THREADS
-    if (f) Py_RETURN_TRUE;
-    Py_RETURN_FALSE;
+    if (f) {
+        Py_RETURN_TRUE;
+    } else {
+        Py_RETURN_FALSE;
+    }
 }
 
 REDUCE_ONE(anynan, DTYPE0) {


### PR DESCRIPTION
Significant performance improvement for `axis=None` cases, particularly with `float32`

```
$ asv compare upstream/master HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [98b59df2]       [22d46a8e]
     <nanmin~1>       <anynan_reduce>
-         559±8ns          502±5ns     0.90  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        850±20μs          757±4μs     0.89  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         876±3μs          777±5μs     0.89  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        742±30μs          655±7μs     0.88  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        564±10ns          497±5ns     0.88  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     2.25±0.08ms      1.98±0.07ms     0.88  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-         578±9ns          496±6ns     0.86  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        825±20μs          693±4μs     0.84  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-       830±300ns          503±7ns     0.61  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-        723±20μs         257±20μs     0.35  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-       785±100μs          254±3μs     0.32  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-CXXclang++]
-     1.00±0.01ms          257±2μs     0.26  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
-     1.01±0.01ms          254±3μs     0.25  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-CXXg++]
```