### PR TITLE
BLD: begin running tests for ppc64le architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,12 @@ jobs:
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
+        - os: linux
+          arch: ppc64le
+          env: TEST_DEPS="numpy pytest hypothesis"
+               PYTHON_VERSION="3.7"
+               PYTHON_ARCH="64"
+
          # python 3.8 conda numpy
         - os: linux
           env: TEST_DEPS="pytest hypothesis"

--- a/tools/travis/conda_setup.sh
+++ b/tools/travis/conda_setup.sh
@@ -21,7 +21,12 @@ fi
 if [ `uname -m` == 'aarch64' ]; then
     URL="${ARCHICONDA_URL}/build-tools/releases/download/0.2.2/Archiconda3-0.2.2-Linux-aarch64.sh"
 elif [ "${PYTHON_ARCH}" == "64" ]; then
-    URL="${CONDA_URL}/${CONDA}-latest-${CONDA_OS}-x86_64.sh"
+    if [ "${TRAVIS_CPU_ARCH}" == "amd64" ]; then
+        ARCH="x86_64"
+    else
+        ARCH="${TRAVIS_CPU_ARCH}"
+    fi
+    URL="${CONDA_URL}/${CONDA}-latest-${CONDA_OS}-${ARCH}.sh"
 else
     URL="${CONDA_URL}/${CONDA}-latest-${CONDA_OS}-x86.sh"
 fi


### PR DESCRIPTION
Now that we're testing on arm64, add ppc64le as well.