### PR TITLE
BLD: Switch from Archiconda to Miniforge for aarch64

### DIFF
--- a/tools/travis/conda_install.sh
+++ b/tools/travis/conda_install.sh
@@ -14,25 +14,15 @@ export TEST_NAME
 # split dependencies into separate packages
 IFS=" " TEST_DEPS=(${TEST_DEPS})
 echo "Creating environment '${TEST_NAME}'..."
-if [ `uname -m` == 'aarch64' ]; then
-    sudo conda create -q -n "${TEST_NAME}" python="${PYTHON_VERSION}" "${TEST_DEPS[@]}"
-else
-    conda create -q -n "${TEST_NAME}" python="${PYTHON_VERSION}" "${TEST_DEPS[@]}"
-fi
+conda create -q -n "${TEST_NAME}" python="${PYTHON_VERSION}" "${TEST_DEPS[@]}"
+
 
 set +v # we dont want to see commands in the conda script
 
-if [ `uname -m` == 'aarch64' ]; then
-    source activate "${TEST_NAME}"
-    sudo conda update pip
-    sudo conda info -a
-    sudo conda list
-else
-    source activate "${TEST_NAME}"
-    conda update pip
-    conda info -a
-    conda list
-fi
+source activate "${TEST_NAME}"
+conda update pip
+conda info -a
+conda list
 
 if [ -n "${PIP_DEPS}" ]; then
     pip install --upgrade pip


### PR DESCRIPTION
It appears Archiconda has been superseded by Miniforge, which is aiming for upstreaming with conda generally. Switch to Miniforge and de-dupe some of the installer logic.

cc @odidev 