### PR TITLE
PERF: introduce SSE2 implementations of allnan/anynan, ~30% speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
 
         - os: linux
           arch: ppc64le
-          env: TEST_DEPS="numpy pytest hypothesis"
+          env: TEST_DEPS="numpy pytest hypothesis gfortran_linux-ppc64le=8.2.0"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
@@ -98,7 +98,7 @@ install:
     - source "tools/travis/conda_install.sh"
 
 script:
-    - source "tools/travis/bn_setup.sh"
+    - ./tools/travis/bn_setup.sh
 
 notifications:
     email:

--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -8,6 +8,8 @@ OPTIONAL_FUNCTION_ATTRIBUTES = [
     ("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3", '__attribute__((optimize("O3")))')
 ]
 
+OPTIONAL_HEADERS = [("HAVE_SSE2", "emmintrin.h")]
+
 OPTIONAL_INTRINSICS = [
     ("HAVE___BUILTIN_ISNAN", "__builtin_isnan", "0."),
     ("HAVE_ISNAN", "isnan", "0."),
@@ -101,6 +103,10 @@ def check_gcc_function_attribute(cmd, attribute, name):
         return False
 
 
+def check_gcc_header(cmd, header):
+    return cmd.check_header(header)
+
+
 def check_gcc_intrinsic(cmd, intrinsic, value) -> bool:
     """Return True if the given intrinsic is supported."""
     body = (
@@ -138,6 +144,12 @@ def create_config_h(config):
 
     for config_attr, func_attr in OPTIONAL_FUNCTION_ATTRIBUTES:
         if check_gcc_function_attribute(config, func_attr, config_attr.lower()):
+            output.append((config_attr, "1"))
+        else:
+            output.append((config_attr, "0"))
+
+    for config_attr, header in OPTIONAL_HEADERS:
+        if check_gcc_header(config, header):
             output.append((config_attr, "1"))
         else:
             output.append((config_attr, "0"))

--- a/tools/travis/bn_setup.sh
+++ b/tools/travis/bn_setup.sh
@@ -19,10 +19,9 @@ else
         pip install "${ARCHIVE[0]}"
     elif [ "${TEST_RUN}" != "coverage" ]; then
         # CFLAGS gets ignored by PEP 518, so do coverage from inplace build
-        pip install --upgrade --user pip
-        pip install --user "."
+        pip install "."
     fi
-    python setup.py build_ext --user --inplace
+    python setup.py build_ext --inplace
     if [ "${TEST_RUN}" == "doc" ]; then
         make doc
     elif [ "${TEST_RUN}" == "coverage" ]; then


### PR DESCRIPTION
SSE2 is pretty much universal, so start explicitly invoking it as compilers don't seem to want to use it for `allnan`/`anynan`. 

Speedup is sufficient to bring us to parity with numpy in the slow case, which means we are now strictly better than numpy here. Still need to implement for `axis != None`, but looking very promising:
```
asv compare HEAD^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [61eea5ab]       [ff4ee4b4]
     <ppc64le>                  
-        262±10μs          224±9μs     0.86  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        778±40μs          604±9μs     0.78  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        790±30μs         605±90μs     0.77  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        805±10μs         592±10μs     0.74  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        766±10μs         558±40μs     0.73  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-         708±3μs         510±20μs     0.72  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        729±30μs         518±20μs     0.71  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        775±30μs         543±10μs     0.70  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        801±10μs         540±20μs     0.67  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        808±10μs          532±9μs     0.66  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
       before           after         ratio
     [61eea5ab]       [ff4ee4b4]
     <ppc64le>                  
+        271±10μs         299±20μs     1.10  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', None, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
```