### PR TITLE
BLD: add explicit py38 numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ requires = [
     "numpy==1.13.3; python_version=='2.7' and platform_system!='AIX'",
     "numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'",
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.14.5; python_version>='3.7' and platform_system!='AIX'",
+    "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='2.7' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version>='3.7' and platform_system=='AIX'",
+    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
 ]


### PR DESCRIPTION
Backport fix for #306 