### PR TITLE
PERF: speed up nansum for integer inputs with axis != None by up to ~6x

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -159,6 +159,7 @@ REDUCE_ALL(nansum, DTYPE0) {
     return PyLong_FromLongLong(asum);
 }
 
+BN_OPT_3
 REDUCE_ONE(nansum, DTYPE0) {
     npy_DTYPE0 asum;
     INIT_ONE(DTYPE0, DTYPE0)
@@ -166,11 +167,39 @@ REDUCE_ONE(nansum, DTYPE0) {
     if (LENGTH == 0) {
         FILL_Y(0)
     } else {
-        WHILE {
-            asum = 0;
-            FOR asum += AI(DTYPE0);
-            YPP = asum;
-            NEXT
+        if (ONE_CONTIGUOUS) {
+            WHILE {
+                asum = 0;
+                const npy_DTYPE0* pa = PA(DTYPE0);
+                FOR {
+                    asum += SI(pa);
+                }
+                YPP = asum;
+                NEXT
+            }
+        } else if (ONE_TRANSPOSE(npy_DTYPE0)) {
+            const npy_intp LOOP_SIZE = it.nits;
+            const npy_DTYPE0* pa = PA(DTYPE0);
+
+            for (npy_intp i=0; i < LOOP_SIZE; i++) {
+                py[i] = 0;
+            }
+
+            for (npy_intp i=0; i < LENGTH; i++) {
+                for (npy_intp j=0; j < LOOP_SIZE; j++) {
+                    py[j] += pa[i * LOOP_SIZE + j];
+                }
+            }
+        } else {
+            WHILE {
+                asum = 0;
+                const npy_DTYPE0* pa = PA(DTYPE0);
+                FOR {
+                    asum += SI(pa);
+                }
+                YPP = asum;
+                NEXT
+            }
         }
     }
     BN_END_ALLOW_THREADS


### PR DESCRIPTION
Get up to ~6x speedup for `nansum` on integer inputes with non-null `axis`.

```
$ asv compare HEAD^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [7ac219a0]       [7988b9f0]
     <int_nansum~1>       <int_nansum>
-        571±10μs         380±40μs     0.67  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-         785±8μs         513±50μs     0.65  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-         571±9μs         372±10μs     0.65  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-         778±8μs         483±80μs     0.62  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        795±80μs         431±20μs     0.54  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        790±10μs         426±10μs     0.54  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.17±0.02ms          632±8μs     0.54  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.18±0.03ms         631±20μs     0.53  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      1.19±0.1ms         634±20μs     0.53  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        791±10μs          420±7μs     0.53  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     1.19±0.08ms         633±30μs     0.53  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.20±0.07ms          632±4μs     0.53  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.27±0.02ms          632±3μs     0.50  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      1.30±0.1ms         631±10μs     0.49  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      1.39±0.2ms         632±50μs     0.46  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      1.10±0.2ms          471±7μs     0.43  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-         355±8μs          150±9μs     0.42  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-         358±5μs         147±30μs     0.41  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        593±70μs         210±20μs     0.35  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-         582±9μs          202±4μs     0.35  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        579±20μs         200±20μs     0.35  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        586±30μs         203±30μs     0.35  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        582±20μs          176±4μs     0.30  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        581±40μs          174±4μs     0.30  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-       786±100μs         184±60μs     0.23  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        783±90μs         173±40μs     0.22  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        776±30μs        167±0.5μs     0.22  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        788±20μs         169±20μs     0.21  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        786±20μs        167±0.4μs     0.21  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-       819±200μs         169±20μs     0.21  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        699±50μs         136±30μs     0.19  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        694±70μs          122±5μs     0.18  reduce.Time2DReductions.time_nansum('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
       before           after         ratio
     [7ac219a0]       [7988b9f0]
     <int_nansum~1>       <int_nansum>
+         414±9μs         460±60μs     1.11  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
```