### PR TITLE
PERF: optimize anynan/allnan with transpose axis

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1333,6 +1333,47 @@ REDUCE_ONE(anynan, DTYPE0) {
                 YPP = f;
                 NEXT
            }
+        } else if (ONE_TRANSPOSE(npy_DTYPE0)) {
+            const npy_intp LOOP_SIZE = it.nits;
+            const npy_DTYPE0* pa = PA(DTYPE0);
+
+            for (npy_intp i=0; i < LOOP_SIZE; i++) {
+                py[i] = 0;
+            }
+
+            const npy_intp loop_count = LENGTH / 16;
+            const npy_intp residual = LENGTH % 16;
+            npy_intp min_k = 0;
+
+            for (npy_intp i=0; i < residual; i++) {
+                for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                    ai = pa[i * LOOP_SIZE + k];
+                    py[k] = bn_isnan(ai) ? 1 : py[k];
+                    if ((k == min_k) && py[k]) {
+                        min_k++;
+                    }
+                }
+            }
+
+            for (npy_intp i=0; (i < loop_count) && (min_k < LOOP_SIZE - 1); i++) {
+                for (npy_intp j=0; j < 16; j++) {
+                    for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                        ai = pa[(i * 16 + j + residual) * LOOP_SIZE + k];
+                        py[k] = bn_isnan(ai) ? 1 : py[k];
+                    }
+                }
+                for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                    if (py[k] == 0) {
+                        min_k = k;
+                        break;
+                    } else if (k == LOOP_SIZE - 1) {
+                        min_k = k;
+                    }
+                }
+                if (min_k == LOOP_SIZE - 1) {
+                    break;
+                }
+            }
         } else {
             WHILE {
                 f = 0;
@@ -1500,6 +1541,51 @@ REDUCE_ONE(allnan, DTYPE0) {
                 YPP = !f;
                 NEXT
            }
+        } else if (ONE_TRANSPOSE(npy_DTYPE0)) {
+            const npy_intp LOOP_SIZE = it.nits;
+            const npy_DTYPE0* pa = PA(DTYPE0);
+
+            for (npy_intp i=0; i < LOOP_SIZE; i++) {
+                py[i] = 0;
+            }
+
+            const npy_intp loop_count = LENGTH / 16;
+            const npy_intp residual = LENGTH % 16;
+            npy_intp min_k = 0;
+
+            for (npy_intp i=0; i < residual; i++) {
+                for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                    ai = pa[i * LOOP_SIZE + k];
+                    py[k] = !bn_isnan(ai) ? 1 : py[k];
+                    if ((k == min_k) && py[k]) {
+                        min_k++;
+                    }
+                }
+            }
+
+            for (npy_intp i=0; (i < loop_count) && (min_k < LOOP_SIZE - 1); i++) {
+                for (npy_intp j=0; j < 16; j++) {
+                    for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                        ai = pa[(i * 16 + j + residual) * LOOP_SIZE + k];
+                        py[k] = !bn_isnan(ai) ? 1 : py[k];
+                    }
+                }
+                for (npy_intp k=min_k; k < LOOP_SIZE; k++) {
+                    if (py[k] == 0) {
+                        min_k = k;
+                        break;
+                    } else if (k == LOOP_SIZE - 1) {
+                        min_k = k;
+                    }
+                }
+                if (min_k == LOOP_SIZE - 1) {
+                    break;
+                }
+            }
+
+            for (npy_intp k=0; k < LOOP_SIZE; k++) {
+                py[k] = !py[k];
+            }
         } else {
             WHILE {
                 f = 0;


### PR DESCRIPTION
Handle the transpose case in `anynan()`/`allnan()`. Speedups of up to 4x:
```
$ asv compare HEAD^ HEAD -s --sort ratio

Benchmarks that have improved:

       before           after         ratio
     [8b587c5c]       [fc95c3d5]
     <anynan_sse2~1>       <anynan_sse2>
-        409±90ns          366±9ns     0.90  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', None, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        602±60ns         536±20ns     0.89  reduce.TimeAnyNan2D.time_anynan('int32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        610±60ns         542±20ns     0.89  reduce.TimeAnyNan2D.time_anynan('int64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      9.02±0.3μs      7.99±0.07μs     0.89  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        599±50ns          530±3ns     0.88  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      8.66±0.8μs       7.59±0.6μs     0.88  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      8.98±0.1μs       7.85±0.1μs     0.87  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        621±40ns         535±30ns     0.86  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      8.99±0.1μs       7.72±0.2μs     0.86  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        314±70μs         270±20μs     0.86  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        613±50ns          524±9ns     0.85  reduce.TimeAllNan2D.time_allnan('int64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        623±30ns         523±20ns     0.84  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        634±50ns          529±9ns     0.83  reduce.TimeAllNan2D.time_allnan('int32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        9.66±2μs       7.59±0.3μs     0.79  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      9.61±0.7μs       7.39±0.4μs     0.77  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     3.42±0.07μs      2.60±0.05μs     0.76  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.45±0.2μs       2.59±0.1μs     0.75  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.48±0.3μs       2.62±0.2μs     0.75  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.41±0.3μs       2.53±0.1μs     0.74  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        369±30μs         272±20μs     0.74  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        368±10μs         272±10μs     0.74  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      3.47±0.2μs      2.54±0.06μs     0.73  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.49±0.7μs       2.55±0.3μs     0.73  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.53±0.2μs      2.56±0.05μs     0.73  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      3.49±0.2μs       2.53±0.2μs     0.72  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        996±50μs         685±30μs     0.69  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-        981±40μs         666±20μs     0.68  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-     1.02±0.08ms         684±20μs     0.67  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      1.03±0.1ms         669±80μs     0.65  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-     1.39±0.06ms         786±20μs     0.57  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      1.40±0.1ms         792±10μs     0.57  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      1.42±0.1ms         786±30μs     0.55  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-     1.42±0.05ms         776±10μs     0.55  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      5.26±0.1μs       2.48±0.3μs     0.47  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      4.89±0.1μs       2.30±0.1μs     0.47  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      4.82±0.1μs       2.25±0.1μs     0.47  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      5.31±0.1μs      2.43±0.09μs     0.46  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      4.03±0.2μs      1.83±0.06μs     0.45  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      5.40±0.2μs      2.42±0.07μs     0.45  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      5.43±0.3μs       2.42±0.1μs     0.45  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      4.28±0.2μs      1.88±0.07μs     0.44  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     4.80±0.09μs      2.10±0.06μs     0.44  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      4.86±0.2μs      2.03±0.09μs     0.42  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.37±0.09ms         539±80μs     0.39  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.34±0.09ms         525±60μs     0.39  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     1.38±0.08ms         536±50μs     0.39  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.42±0.06ms         551±80μs     0.39  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      1.40±0.1ms         539±60μs     0.39  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     1.42±0.08ms         537±30μs     0.38  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.42±0.08ms         536±20μs     0.38  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      1.44±0.1ms         535±30μs     0.37  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.36±0.07ms         500±30μs     0.37  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      1.38±0.2ms         505±20μs     0.37  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      4.27±0.2μs      1.56±0.02μs     0.36  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      4.27±0.3μs      1.55±0.04μs     0.36  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      1.42±0.1ms         512±20μs     0.36  reduce.TimeAnyNan2D.time_anynan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     3.86±0.09μs      1.36±0.09μs     0.35  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        931±30μs         327±60μs     0.35  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      3.91±0.2μs      1.35±0.09μs     0.34  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      1.47±0.2ms         507±30μs     0.34  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      3.96±0.2μs      1.32±0.02μs     0.33  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        920±70μs         303±20μs     0.33  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      4.00±0.2μs      1.30±0.03μs     0.32  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-     4.60±0.08μs      1.45±0.03μs     0.32  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        939±30μs         292±50μs     0.31  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      4.66±0.3μs      1.45±0.08μs     0.31  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      5.52±0.3μs       1.68±0.1μs     0.30  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        958±70μs          289±9μs     0.30  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        973±80μs         291±70μs     0.30  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     4.34±0.05μs      1.29±0.07μs     0.30  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     4.22±0.09μs      1.25±0.02μs     0.30  reduce.TimeAllNan2D.time_allnan('float64', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     5.46±0.08μs      1.59±0.01μs     0.29  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-     1.11±0.04ms         316±50μs     0.28  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-       988±100μs         277±20μs     0.28  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      4.70±0.2μs       1.29±0.2μs     0.27  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      1.04±0.1ms         282±20μs     0.27  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.11±0.03ms         292±10μs     0.26  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      1.08±0.2ms         278±10μs     0.26  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      1.15±0.2ms         295±30μs     0.26  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      4.86±0.2μs      1.23±0.02μs     0.25  reduce.TimeAllNan2D.time_allnan('float32', (1000, 1000), 'F', 1, 'fast') [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-     1.15±0.09ms         289±20μs     0.25  reduce.TimeAnyNan2D.time_anynan('float32', (1000, 1000), 'C', 0, 'slow') [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
```