### PR TITLE
BUG: match behavior of scipy.stats.ss for int32 inputs

### DIFF
--- a/bottleneck/src/bottleneck.h
+++ b/bottleneck/src/bottleneck.h
@@ -27,6 +27,7 @@
 #define NPY_int64   NPY_INT64
 #define NPY_int32   NPY_INT32
 #define NPY_intp    NPY_INTP
+#define NPY_long    NPY_LONG
 #define NPY_MAX_int64 NPY_MAX_INT64
 #define NPY_MAX_int32 NPY_MAX_INT32
 #define NPY_MIN_int64 NPY_MIN_INT64

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -942,25 +942,38 @@ REDUCE_ONE(ss, DTYPE0) {
 }
 /* dtype end */
 
-/* dtype = [['int64'], ['int32']] */
+/* dtype = [['int64', 'int64'], ['int32', 'long']] */
+BN_OPT_3
 REDUCE_ALL(ss, DTYPE0) {
-    npy_DTYPE0 ai, asum = 0;
+    npy_DTYPE0 ai;
+    npy_DTYPE1 asum = 0;
     INIT_ALL
     BN_BEGIN_ALLOW_THREADS
-    WHILE {
-        FOR {
-            ai = AI(DTYPE0);
+    if (REDUCE_CONTIGUOUS) {
+        const npy_intp count = it.nits * it.length;
+        const npy_DTYPE0* pa = PA(DTYPE0);
+        for (npy_intp i=0; i<count; i++) {
+            ai = pa[i];
             asum += ai * ai;
         }
-        NEXT
+    } else {
+        WHILE {
+            FOR {
+                ai = AI(DTYPE0);
+                asum += ai * ai;
+            }
+            NEXT
+        }
     }
     BN_END_ALLOW_THREADS
     return PyLong_FromLongLong(asum);
 }
 
+BN_OPT_3
 REDUCE_ONE(ss, DTYPE0) {
-    npy_DTYPE0 ai, asum;
-    INIT_ONE(DTYPE0, DTYPE0)
+    npy_DTYPE0 ai;
+    npy_DTYPE1 asum;
+    INIT_ONE(DTYPE1, DTYPE1)
     BN_BEGIN_ALLOW_THREADS
     if (LENGTH == 0) {
         FILL_Y(0)

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -19,6 +19,10 @@ from hypothesis.extra.numpy import (
 )
 
 
+hy_int_array_gen = hy_arrays(
+    dtype=integer_dtypes(sizes=(32, 64)), shape=array_shapes(),
+)
+
 hy_array_gen = hy_arrays(
     dtype=one_of(integer_dtypes(sizes=(32, 64)), floating_dtypes(sizes=(32, 64))),
     shape=array_shapes(),
@@ -66,6 +70,13 @@ def _hypothesis_helper(func, array, skip_all_nans=False):
 @hypothesis.given(array=hy_array_gen)
 @hypothesis.settings(max_examples=500)
 def test_reduce_hypothesis(func, array):
+    _hypothesis_helper(func, array)
+
+
+@pytest.mark.parametrize("func", (bn.ss,), ids=lambda x: x.__name__)
+@hypothesis.given(array=hy_int_array_gen)
+@hypothesis.settings(max_examples=500)
+def test_reduce_hypothesis_ints_only(func, array):
     _hypothesis_helper(func, array)
 
 


### PR DESCRIPTION
Add hypothesis testing for `bn.reduce.ss` with integer inputs and resolve some discrepancies. Comes with a performance hit, but further optimization is possible.

Float inputs require pairwise summation to get an exact match.

```
$ asv compare HEAD^ HEAD -s --sort ratio --only-changed
       before           after         ratio
     [f1d14dc2]       [b21e3c30]
     <bn_isnan~1>       <ss>      
-        63.6±2μs       54.8±0.9μs     0.86  reduce.Time1DReductions.time_ss('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      8.10±0.5ms       6.96±0.4ms     0.86  reduce.Time1DReductions.time_ss('int64', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-       964±200ns          787±7ns     0.82  reduce.Time1DReductions.time_ss('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-         798±6μs         651±10μs     0.82  reduce.Time2DReductions.time_ss('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        801±60μs         649±10μs     0.81  reduce.Time2DReductions.time_ss('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        800±70μs         647±20μs     0.81  reduce.Time2DReductions.time_ss('int64', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        730±60μs          587±7μs     0.80  reduce.Time2DReductions.time_ss('int64', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-         978±4ns          786±9ns     0.80  reduce.Time1DReductions.time_ss('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        954±50ns         765±40ns     0.80  reduce.Time1DReductions.time_ss('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-         900±5ns          721±6ns     0.80  reduce.Time1DReductions.time_ss('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-      60.6±0.4μs         47.9±1μs     0.79  reduce.Time1DReductions.time_ss('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        906±10ns         713±40ns     0.79  reduce.Time1DReductions.time_ss('int64', (1000,)) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-      6.33±0.2ms       4.67±0.1ms     0.74  reduce.Time1DReductions.time_ss('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-         610±5μs          442±7μs     0.73  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-        989±70ns         714±40ns     0.72  reduce.Time1DReductions.time_ss('int32', (1000,)) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        620±60μs         447±60μs     0.72  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      6.40±0.2ms      4.61±0.05ms     0.72  reduce.Time1DReductions.time_ss('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
-       623±100μs         448±50μs     0.72  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-      57.3±0.8μs       38.5±0.9μs     0.67  reduce.Time1DReductions.time_ss('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-7-CXXg++-7]
-        676±10μs          443±8μs     0.66  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'F', None) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-        679±40μs          441±7μs     0.65  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-      60.0±0.6μs         38.2±1μs     0.64  reduce.Time1DReductions.time_ss('int32', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
-       56.7±10μs       33.3±0.9μs     0.59  reduce.Time1DReductions.time_ss('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
-       88.4±30μs       47.2±0.4μs     0.53  reduce.Time1DReductions.time_ss('int64', (100000,)) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
       before           after         ratio
     [f1d14dc2]       [b21e3c30]
     <bn_isnan~1>       <ss>      
+     1.11±0.07ms       1.73±0.3ms     1.55  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
+     1.10±0.05ms       1.47±0.2ms     1.34  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'F', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
+      4.10±0.2ms      5.26±0.05ms     1.28  reduce.Time1DReductions.time_ss('int32', (10000000,)) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
+         417±6μs         535±40μs     1.28  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', None) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
+        916±30μs       1.17±0.2ms     1.28  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', 0) [T470/conda-py3.7-numpy1.16-CCclang-9-CXXclang++-9]
+         687±9μs         791±50μs     1.15  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'C', 1) [T470/conda-py3.7-numpy1.16-CCgcc-9-CXXg++-9]
+         637±6μs        730±100μs     1.15  reduce.Time2DReductions.time_ss('int32', (1000, 1000), 'F', 0) [T470/conda-py3.7-numpy1.16-CCgcc-8-CXXg++-8]
```