### PR TITLE
Make installation process more robust for users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,8 @@ Unit tests               pytest, hypothesis
 Documentation            sphinx, numpydoc
 ======================== ====================================================
 
+Detailed installation instructions can be found at :ref:`installing`
+
 To install Bottleneck on Linux, Mac OS X, et al.::
 
     $ pip install .

--- a/bottleneck/tests/docker/centos_7_min_deps/Dockerfile
+++ b/bottleneck/tests/docker/centos_7_min_deps/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7
+RUN yum update -y
+RUN yum install -y gcc python3-devel python3-pip
+RUN pip3 install --upgrade pip
+WORKDIR /tmp
+CMD ["pip3", "install", "/bottleneck_src"]

--- a/bottleneck/tests/docker/centos_8_min_deps/Dockerfile
+++ b/bottleneck/tests/docker/centos_8_min_deps/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:8
+RUN yum update -y
+RUN yum install -y gcc python3-devel python3-pip
+RUN pip3 install --upgrade pip
+WORKDIR /tmp
+CMD ["pip3", "install", "/bottleneck_src"]

--- a/bottleneck/tests/docker/release_tests.sh
+++ b/bottleneck/tests/docker/release_tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+rm -rf temp_clone
+git clone ../../.. temp_clone
+
+cases=(centos_7_min_deps centos_8_min_deps ubuntu_lts_min_deps ubuntu_devel_min_deps)
+for case in ${cases[@]}; do
+    echo $case
+    docker build -t $case $case
+    docker run --mount type=bind,source=$(pwd)/temp_clone,destination=/bottleneck_src,readonly $case
+done
+
+rm -rf temp_clone

--- a/bottleneck/tests/docker/ubuntu_devel_min_deps/Dockerfile
+++ b/bottleneck/tests/docker/ubuntu_devel_min_deps/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:devel
+RUN apt-get update
+RUN apt-get install -y gcc python3-dev python3-pip
+RUN pip3 install --upgrade pip
+WORKDIR /tmp
+CMD ["pip3", "install", "/bottleneck_src"]

--- a/bottleneck/tests/docker/ubuntu_lts_min_deps/Dockerfile
+++ b/bottleneck/tests/docker/ubuntu_lts_min_deps/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:latest
+RUN apt-get update
+RUN apt-get install -y gcc python3-dev python3-pip
+RUN pip3 install --upgrade pip
+WORKDIR /tmp
+CMD ["pip3", "install", "/bottleneck_src"]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ Table of Contents
    :maxdepth: 3
    
    intro
+   installing
    reference
    release
    license

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -1,0 +1,73 @@
+.. _installing:
+
+Installing Bottleneck
+=====================
+
+As bottleneck aims to provide high-performance, optimized numerical functions
+to all users, it is distributed as a source package (except via Anaconda) so
+that local compilers can perform the relevant optimizations. Accordingly,
+installation may take some additional steps compared to packages like numpy.
+
+Anaconda
+~~~~~~~~
+
+If you wish to avoid additional steps, we recommend using Anaconda or Miniconda.
+A pre-compiled version of bottleneck is installed by default. Users looking for
+optimal performance may benefit from uninstalling the pre-compiled version and
+following the steps below.
+
+Build dependencies
+~~~~~~~~~~~~~~~~~~
+
+Debian & Ubuntu
+---------------
+
+The following build packages must be installed prior to installing bottleneck:
+
+.. code-block::
+
+   sudo apt install gcc python3-dev
+
+The Python development headers can be excluded if using Anaconda.
+
+RHEL, Fedora & CentOS
+---------------------
+
+.. code-block::
+
+   sudo yum install gcc python3-devel
+
+Windows
+-------
+
+The Python Wiki maintains detailed instructions on which Visual Studio version to install here: https://wiki.python.org/moin/WindowsCompilers
+
+
+pip & setuptools
+~~~~~~~~~~~~~~~~
+
+bottleneck leverages :pep:`517` and thus we generally recommend updating pip and setuptools before installing to leverage recent improvements.
+
+With Anaconda:
+
+.. code-block::
+
+   conda update setuptools pip
+
+And with pip:
+
+.. code-block::
+
+   pip install --upgrade setuptools pip
+
+
+Installation
+~~~~~~~~~~~~
+
+Finally, simply install with:
+
+.. code-block::
+
+   pip install bottleneck
+
+If you encounter any errors, please open an issue on our GitHub page: https://github.com/pydata/bottleneck/issues


### PR DESCRIPTION
Given our lack of wheels, installation is more complex than some other projects. Attempt to improve the user experience in a few ways:
 - Add dedicated installation page in documentation
 - Do a test compile to see if a compiler and/or Python development libraries are even available, and point users to installation page if not.
 - Add explicit Docker-based tests for minimum installation dependencies for a few OSes
 - Specify the C standard used when compiling under `gcc=4.8` or lower, which is the default on RHEL/CentOS 7

cc #281 