### PR TITLE
STY: run isort as part of CI and run on remaining files

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -58,6 +58,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --statistics
+    - name: Check import sorting with isort
+      if: matrix.python-version >= 3.6
+      run: |
+        pip install isort
+        isort -c -df -rc .
     - name: Check formatting with black
       if: matrix.python-version >= 3.6
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ jobs:
     fast_finish: true
     include:
         - stage: style
-        # flake8 and black
+          # flake8, black, and isort
           os: linux
-          env: TEST_DEPS="flake8 black"
+          env: TEST_DEPS="flake8 black isort"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
                TEST_RUN="style"

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,13 @@ srcdir := bottleneck
 help:
 	@echo "Available tasks:"
 	@echo "help    -->  This help page"
-	@echo "all     -->  clean, build, flake8, test"
+	@echo "all     -->  clean, flake8, isort, black, build, test"
 	@echo "build   -->  Build the Python C extensions"
 	@echo "clean   -->  Remove all the build files for a fresh start"
 	@echo "test    -->  Run unit tests"
 	@echo "flake8  -->  Check for pep8 errors"
+	@echo "isort   -->  Run isort to format imports"
+	@echo "black   -->  Run black formatting tool"
 	@echo "readme  -->  Update benchmark results in README.rst"
 	@echo "bench   -->  Run performance benchmark"
 	@echo "detail  -->  Detailed benchmarks for all functions"
@@ -19,7 +21,7 @@ help:
 	@echo "doc     -->  Build Sphinx manual"
 	@echo "pypi    -->  Upload to pypi"
 
-all: clean build test flake8
+all: clean flake8 isort black build test
 
 build:
 	${PYTHON} setup.py build_ext --inplace
@@ -29,6 +31,9 @@ test:
 
 flake8:
 	flake8
+
+isort:
+	isort -rc .
 
 black:
 	black . --exclude "(build/|dist/|\.git/|\.mypy_cache/|\.tox/|\.venv/\.asv/|env|\.eggs)"

--- a/asv_bench/benchmarks/memory.py
+++ b/asv_bench/benchmarks/memory.py
@@ -1,5 +1,6 @@
-import bottleneck as bn
 import numpy as np
+
+import bottleneck as bn
 
 
 class Memory:

--- a/asv_bench/benchmarks/nonreduce.py
+++ b/asv_bench/benchmarks/nonreduce.py
@@ -1,5 +1,6 @@
-import bottleneck as bn
 import numpy as np
+
+import bottleneck as bn
 
 
 class TimeReplace2D:

--- a/asv_bench/benchmarks/reduce.py
+++ b/asv_bench/benchmarks/reduce.py
@@ -1,6 +1,6 @@
-import bottleneck as bn
 import numpy as np
 
+import bottleneck as bn
 
 RAND_ARRAY_CACHE = {}
 

--- a/bottleneck/__init__.py
+++ b/bottleneck/__init__.py
@@ -43,7 +43,6 @@ except ImportError:
 from bottleneck.benchmark.bench import bench
 from bottleneck.benchmark.bench_detailed import bench_detailed
 from bottleneck.tests.util import get_functions
-
 from ._pytesttester import PytestTester
 from ._version import get_versions  # noqa: E402
 

--- a/bottleneck/benchmark/bench.py
+++ b/bottleneck/benchmark/bench.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import bottleneck as bn
-
 from .autotimeit import autotimeit
 
 __all__ = ["bench"]

--- a/bottleneck/benchmark/bench_detailed.py
+++ b/bottleneck/benchmark/bench_detailed.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import bottleneck as bn
-
 from .autotimeit import autotimeit
 
 __all__ = ["bench_detailed"]

--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -4,9 +4,8 @@ Unfortunately that file is not exposed, so re-implement the portions we need.
 import os
 import sys
 import textwrap
-from typing import List
 from distutils.command.config import config as Config
-
+from typing import List
 
 OPTIONAL_FUNCTION_ATTRIBUTES = [
     ("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3", '__attribute__((optimize("O3")))')

--- a/bottleneck/src/bn_template.py
+++ b/bottleneck/src/bn_template.py
@@ -1,8 +1,8 @@
-import os
-import re
 import ast
-from typing import List, Optional, Dict, Pattern, Tuple
+import os
 import posixpath as path
+import re
+from typing import Dict, List, Optional, Pattern, Tuple
 
 
 def make_c_files(

--- a/bottleneck/tests/list_input_test.py
+++ b/bottleneck/tests/list_input_test.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.testing import assert_array_almost_equal
 
 import bottleneck as bn
-
 from .util import DTYPES
 
 

--- a/bottleneck/tests/move_test.py
+++ b/bottleneck/tests/move_test.py
@@ -5,7 +5,6 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 
 import bottleneck as bn
-
 from .util import array_order, arrays
 
 

--- a/bottleneck/tests/nonreduce_axis_test.py
+++ b/bottleneck/tests/nonreduce_axis_test.py
@@ -8,7 +8,6 @@ from numpy.testing import (
 )
 
 import bottleneck as bn
-
 from .reduce_test import unit_maker as reduce_unit_maker
 from .reduce_test import unit_maker_argparse as unit_maker_parse_rankdata
 from .util import DTYPES, array_order, arrays

--- a/bottleneck/tests/nonreduce_test.py
+++ b/bottleneck/tests/nonreduce_test.py
@@ -7,7 +7,6 @@ import pytest
 from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
 import bottleneck as bn
-
 from .util import DTYPES, INT_DTYPES, array_order, arrays
 
 

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -10,7 +10,6 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 
 import bottleneck as bn
-
 from .util import DTYPES, array_order, arrays, hy_array_gen, hy_int_array_gen
 
 

--- a/bottleneck/tests/scalar_input_test.py
+++ b/bottleneck/tests/scalar_input_test.py
@@ -5,11 +5,10 @@ from typing import Callable, Union
 import hypothesis
 import numpy as np
 import pytest
+from hypothesis.strategies import floats, integers, one_of
 from numpy.testing import assert_array_almost_equal
-from hypothesis.strategies import integers, floats, one_of
 
 import bottleneck as bn  # noqa: F401
-
 from .util import get_functions
 
 int64_iinfo = np.iinfo(np.int64)

--- a/bottleneck/tests/test_template.py
+++ b/bottleneck/tests/test_template.py
@@ -1,5 +1,4 @@
 import os
-
 import posixpath as path
 
 from ..src.bn_template import make_c_files

--- a/bottleneck/tests/util.py
+++ b/bottleneck/tests/util.py
@@ -1,8 +1,9 @@
 from typing import Callable, List, Union
 
 import numpy as np
-from hypothesis.extra.numpy import array_shapes, floating_dtypes, integer_dtypes
+from hypothesis.extra.numpy import array_shapes
 from hypothesis.extra.numpy import arrays as hy_arrays
+from hypothesis.extra.numpy import floating_dtypes, integer_dtypes
 from hypothesis.strategies import one_of
 
 import bottleneck as bn

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -20,7 +21,8 @@ import sys, os
 sys.path.insert(0, os.path.abspath("../sphinxext"))
 if "READTHEDOCS" not in os.environ or not os.environ["READTHEDOCS"]:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
-import bottleneck
+
+import bottleneck  # isort:skip
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -10,10 +10,11 @@ This will be replaced with a message indicating the number of
 code contributors and commits, and then list each contributor
 individually.
 """
-from announce import build_components
+import git
 from docutils import nodes
 from docutils.parsers.rst import Directive
-import git
+
+from announce import build_components
 
 
 class ContributorsDirective(Directive):

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,5 +32,17 @@ norecursedirs =
     venv
     env
 
+[tool:isort]
+default_section = FIRSTPARTY
+include_trailing_comma = True
+line_length = 88
+known_first_party = bottleneck
+known_standard_library = posixpath
+known_third_party = pandas,git,docutils,numpy,pytest,hypothesis
+multi_line_output = 3
+no_lines_before = LOCALFOLDER
+skip = bottleneck/tests/docker/temp_clone/, .eggs/
+skip_glob = **/env
+
 [build_sphinx]
 warning_is_error = True

--- a/tools/travis/bn_setup.sh
+++ b/tools/travis/bn_setup.sh
@@ -11,6 +11,7 @@ fi
 
 if [ "${TEST_RUN}" == "style" ]; then
     flake8
+    isort -rc -c -df .
     black . --check --exclude "(build/|dist/|\.git/|\.mypy_cache/|\.tox/|\.venv/\.asv/|env|\.eggs)"
 else
     if [ "${TEST_RUN}" == "sdist" ]; then


### PR DESCRIPTION
Set up `isort` to automatically run and configure to be consistent with `black`. Configure via `Makefile` and to run as part of Github Actions and Travis CI.