### PR TITLE
CLN: reformat with isort 5.x and black

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -61,8 +61,8 @@ jobs:
     - name: Check import sorting with isort
       if: matrix.python-version >= 3.6
       run: |
-        pip install isort
-        isort -c -df -rc .
+        pip install isort>=5
+        isort -c --df .
     - name: Check formatting with black
       if: matrix.python-version >= 3.6
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ jobs:
         - stage: style
           # flake8, black, and isort
           os: linux
-          env: TEST_DEPS="flake8 black isort"
+          env: TEST_DEPS="flake8 isort>=5"
+               PIP_DEPS="black>=20.8b1"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
                TEST_RUN="style"

--- a/bottleneck/__init__.py
+++ b/bottleneck/__init__.py
@@ -1,35 +1,34 @@
 try:
-    from .reduce import (
-        nansum,
-        nanmean,
-        nanstd,
-        nanvar,
-        nanmin,
-        nanmax,
-        median,
-        nanmedian,
-        ss,
-        nanargmin,
-        nanargmax,
-        anynan,
-        allnan,
+    from . import slow
+    from .move import (
+        move_argmax,
+        move_argmin,
+        move_max,
+        move_mean,
+        move_median,
+        move_min,
+        move_rank,
+        move_std,
+        move_sum,
+        move_var,
     )
     from .nonreduce import replace
-    from .nonreduce_axis import partition, argpartition, rankdata, nanrankdata, push
-    from .move import (
-        move_sum,
-        move_mean,
-        move_std,
-        move_var,
-        move_min,
-        move_max,
-        move_argmin,
-        move_argmax,
-        move_median,
-        move_rank,
+    from .nonreduce_axis import argpartition, nanrankdata, partition, push, rankdata
+    from .reduce import (
+        allnan,
+        anynan,
+        median,
+        nanargmax,
+        nanargmin,
+        nanmax,
+        nanmean,
+        nanmedian,
+        nanmin,
+        nanstd,
+        nansum,
+        nanvar,
+        ss,
     )
-
-    from . import slow
 
 except ImportError:
     raise ImportError(

--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -34,7 +34,7 @@ def get_python_header_include() -> List[str]:
 
 
 def _get_compiler_list(cmd: Config) -> str:
-    """ Return the compiler command as a list of strings. Distutils provides a
+    """Return the compiler command as a list of strings. Distutils provides a
     wildly inconsistent API here:
       - UnixCCompiler returns a list
       - MSVCCompiler intentionally doesn't set this variable
@@ -118,7 +118,10 @@ def check_gcc_function_attribute(cmd: Config, attribute: str, name: str) -> bool
 
 
 def check_gcc_header(cmd: Config, header: str) -> bool:
-    return cmd.check_header(header, include_dirs=get_python_header_include(),)
+    return cmd.check_header(
+        header,
+        include_dirs=get_python_header_include(),
+    )
 
 
 def check_gcc_intrinsic(cmd: Config, intrinsic: str, value: str) -> bool:

--- a/bottleneck/tests/util.py
+++ b/bottleneck/tests/util.py
@@ -19,7 +19,8 @@ hy_array_gen = hy_arrays(
 )
 
 hy_int_array_gen = hy_arrays(
-    dtype=integer_dtypes(sizes=(32, 64)), shape=array_shapes(),
+    dtype=integer_dtypes(sizes=(32, 64)),
+    shape=array_shapes(),
 )
 
 

--- a/doc/sphinxext/contributors.py
+++ b/doc/sphinxext/contributors.py
@@ -11,10 +11,9 @@ code contributors and commits, and then list each contributor
 individually.
 """
 import git
+from announce import build_components
 from docutils import nodes
 from docutils.parsers.rst import Directive
-
-from announce import build_components
 
 
 class ContributorsDirective(Directive):

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,15 +33,14 @@ norecursedirs =
     env
 
 [tool:isort]
-default_section = FIRSTPARTY
+default_section = THIRDPARTY
 include_trailing_comma = True
 line_length = 88
 known_first_party = bottleneck
-known_standard_library = posixpath
 known_third_party = pandas,git,docutils,numpy,pytest,hypothesis
 multi_line_output = 3
 no_lines_before = LOCALFOLDER
-skip = bottleneck/tests/docker/temp_clone/, .eggs/
+skip = bottleneck/tests/docker/temp_clone/,.eggs/,.tox/
 skip_glob = **/env
 
 [build_sphinx]

--- a/tools/travis/bn_setup.sh
+++ b/tools/travis/bn_setup.sh
@@ -11,7 +11,7 @@ fi
 
 if [ "${TEST_RUN}" == "style" ]; then
     flake8
-    isort -rc -c -df .
+    isort -c --df .
     black . --check --exclude "(build/|dist/|\.git/|\.mypy_cache/|\.tox/|\.venv/\.asv/|env|\.eggs)"
 else
     if [ "${TEST_RUN}" == "sdist" ]; then


### PR DESCRIPTION
`isort 5.x` has some major changes, so adjust our config and perform a bulk reformat.