### PR TITLE
BLD: make test dependencies part of extras and use on CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,18 +41,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-py${{ matrix.python-version }}-pip-
 
-    - name: Install dependencies
+    - name: Install style dependencies
+      if: matrix.python-version >= 3.6
       run: |
         python -m pip install --upgrade pip
-        pip install pytest flake8 hypothesis
-    - name: Install dependencies for Py38 on Windows
-      if: startswith(runner.os, 'Windows') && matrix.python-version == 3.8
-      run: pip install Cython numpy
+        pip install flake8 isort>=5 black>=20.8b1
     - name: Build
       run: |
         python setup.py build_ext --inplace
-        pip install .
+        pip install .[test]
     - name: Lint with flake8
+      if: matrix.python-version >= 3.6
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -61,12 +60,10 @@ jobs:
     - name: Check import sorting with isort
       if: matrix.python-version >= 3.6
       run: |
-        pip install isort>=5
         isort -c --df .
     - name: Check formatting with black
       if: matrix.python-version >= 3.6
       run: |
-        pip install black
         black . --check --exclude "(build/|dist/|\.git/|\.mypy_cache/|\.tox/|\.venv/\.asv/|env|\.eggs)"
     - name: Test with pytest
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ jobs:
 
          # doc check
         - os: linux
-          env: TEST_DEPS="sphinx numpydoc gitpython pytest hypothesis"
-               PYTHON_VERSION="3.7"
+          env: PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
                TEST_RUN="doc"
 
@@ -38,32 +37,31 @@ jobs:
 
          # python 3.6
         - os: linux
-          env: TEST_DEPS="numpy pytest hypothesis"
+          env: TEST_DEPS="numpy"
                PYTHON_VERSION="3.6"
                PYTHON_ARCH="64"
 
          # python 3.7
         - os: linux
-          env: TEST_DEPS="numpy pytest hypothesis"
+          env: TEST_DEPS="numpy"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
         - os: linux
           arch: arm64
-          env: TEST_DEPS="numpy pytest hypothesis"
+          env: TEST_DEPS="numpy"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
         - os: linux
           arch: ppc64le
-          env: TEST_DEPS="numpy pytest hypothesis gfortran_linux-ppc64le=8.2.0"
+          env: TEST_DEPS="numpy gfortran_linux-ppc64le=8.2.0"
                PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
          # python 3.8 conda numpy
         - os: linux
-          env: TEST_DEPS="pytest hypothesis"
-               PYTHON_VERSION="3.8"
+          env: PYTHON_VERSION="3.8"
                PYTHON_ARCH="64"
 
          # python 3.8 conda numpy + sdist
@@ -75,20 +73,17 @@ jobs:
 
         # python 3.6
         - os: osx
-          env: TEST_DEPS="numpy pytest hypothesis"
-               PYTHON_VERSION="3.6"
+          env: PYTHON_VERSION="3.6"
                PYTHON_ARCH="64"
 
         # python 3.7
         - os: osx
-          env: TEST_DEPS="numpy pytest hypothesis"
-               PYTHON_VERSION="3.7"
+          env: PYTHON_VERSION="3.7"
                PYTHON_ARCH="64"
 
         # python 3.8
         - os: osx
-          env: TEST_DEPS="pytest hypothesis"
-               PYTHON_VERSION="3.8"
+          env: PYTHON_VERSION="3.8"
                PYTHON_ARCH="64"
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,15 @@ http://www.lfd.uci.edu/~gohlke/pythonlibs/#bottleneck
 Unit tests
 ==========
 
+To keep the install dependencies light, test dependencies are made available
+via a setuptools "extra":
+
+    $ pip install bottleneck[test]
+
+Or, if working locally:
+
+    $ pip install .[test]
+
 After you have installed Bottleneck, run the suite of unit tests::
 
   In [1]: import bottleneck as bn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ max_jobs: 100
 environment:
 
     global:
-        DEPS: "numpy pytest hypothesis"
+        DEPS: "numpy"
         CONDA_VENV: "testy"
         # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
         # /E:ON and /V:ON options are not enabled in the batch script
@@ -53,6 +53,6 @@ build: false
 test_script:
     - "activate %CONDA_VENV%"
     - "%CMD_IN_ENV% python.exe -m pip install --upgrade pip"
-    - "%CMD_IN_ENV% pip install ."
+    - "%CMD_IN_ENV% pip install .[test]"
     - "%CMD_IN_ENV% python setup.py build_ext --inplace"
     - "python tools\\test-installed-bottleneck.py"

--- a/bottleneck/_pytesttester.py
+++ b/bottleneck/_pytesttester.py
@@ -69,6 +69,12 @@ class PytestTester(object):
 
         pytest_args += ["--pyargs"] + list(tests)
 
+        if not _have_test_extras():
+            warnings.warn(
+                "The pytest and/or hypothesis packages are not installed, install with "
+                "pip install bottleneck[test]"
+            )
+
         try:
             code = pytest.main(pytest_args)
         except SystemExit as exc:
@@ -85,3 +91,12 @@ def _pytest_has_xdist() -> bool:
     from importlib.util import find_spec
 
     return find_spec("xdist") is not None
+
+
+def _have_test_extras() -> bool:
+    """
+    Check if the test extra is installed
+    """
+    from importlib.util import find_spec
+
+    return all(find_spec(x) is not None for x in ["pytest", "hypothesis"])

--- a/bottleneck/tests/common.py
+++ b/bottleneck/tests/common.py
@@ -1,0 +1,14 @@
+from hypothesis.extra.numpy import array_shapes
+from hypothesis.extra.numpy import arrays as hy_arrays
+from hypothesis.extra.numpy import floating_dtypes, integer_dtypes
+from hypothesis.strategies import one_of
+
+hy_array_gen = hy_arrays(
+    dtype=one_of(integer_dtypes(sizes=(32, 64)), floating_dtypes(sizes=(32, 64))),
+    shape=array_shapes(),
+)
+
+hy_int_array_gen = hy_arrays(
+    dtype=integer_dtypes(sizes=(32, 64)),
+    shape=array_shapes(),
+)

--- a/bottleneck/tests/input_modification_test.py
+++ b/bottleneck/tests/input_modification_test.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
-from .util import get_functions, hy_array_gen
+from .common import hy_array_gen
+from .util import get_functions
 
 
 @pytest.mark.parametrize("func", get_functions("all"), ids=lambda x: x.__name__)

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -10,7 +10,8 @@ import pytest
 from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 
 import bottleneck as bn
-from .util import DTYPES, array_order, arrays, hy_array_gen, hy_int_array_gen
+from .common import hy_array_gen, hy_int_array_gen
+from .util import DTYPES, array_order, arrays
 
 
 def _hypothesis_helper(

--- a/bottleneck/tests/util.py
+++ b/bottleneck/tests/util.py
@@ -1,27 +1,12 @@
 from typing import Callable, List, Union
 
 import numpy as np
-from hypothesis.extra.numpy import array_shapes
-from hypothesis.extra.numpy import arrays as hy_arrays
-from hypothesis.extra.numpy import floating_dtypes, integer_dtypes
-from hypothesis.strategies import one_of
 
 import bottleneck as bn
 
 INT_DTYPES = [np.int64, np.int32]
 FLOAT_DTYPES = [np.float64, np.float32]
 DTYPES = tuple(FLOAT_DTYPES + INT_DTYPES)
-
-
-hy_array_gen = hy_arrays(
-    dtype=one_of(integer_dtypes(sizes=(32, 64)), floating_dtypes(sizes=(32, 64))),
-    shape=array_shapes(),
-)
-
-hy_int_array_gen = hy_arrays(
-    dtype=integer_dtypes(sizes=(32, 64)),
-    shape=array_shapes(),
-)
 
 
 def get_functions(

--- a/setup.py
+++ b/setup.py
@@ -210,9 +210,11 @@ metadata = dict(
     version=versioneer.get_version(),
     packages=find_packages(),
     package_data={"bottleneck": ["LICENSE", "tests/data/**/*.c"]},
-    requires=["numpy"],
     install_requires=["numpy"],
-    extras_require={"doc": ["numpydoc", "sphinx", "gitpython"]},
+    extras_require={
+        "doc": ["numpydoc", "sphinx", "gitpython"],
+        "test": ["hypothesis", "pytest"],
+    },
     cmdclass=cmdclass,
     setup_requires=["numpy"],
     ext_modules=prepare_modules(),

--- a/tools/travis/bn_setup.sh
+++ b/tools/travis/bn_setup.sh
@@ -20,7 +20,11 @@ else
         pip install "${ARCHIVE[0]}"
     elif [ "${TEST_RUN}" != "coverage" ]; then
         # CFLAGS gets ignored by PEP 518, so do coverage from inplace build
-        pip install "."
+        EXTRAS="test"
+        if [ "${TEST_RUN}" == "doc" ]; then
+            EXTRAS="${EXTRAS},doc"
+        fi
+        pip install ".[${EXTRAS}]"
     fi
     python setup.py build_ext --inplace
     if [ "${TEST_RUN}" == "doc" ]; then


### PR DESCRIPTION
Resolve #352 by adding a `bottleneck[test]` extra that can be installed with:

    pip install bottleneck[test]

Or, if working off master:

    pip install .[test]

Also, document this in `README`.