### PR TITLE
BUG: decref array when falling back to slow call

### DIFF
--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -916,6 +916,7 @@ mover(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
+        Py_DECREF(a);
         return slow(name, args, kwds);
     }
 

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -647,6 +647,7 @@ nonreducer_axis(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
+        Py_DECREF(a);
         return slow(name, args, kwds);
     }
 

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -238,6 +238,7 @@ nonreducer(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
+        Py_DECREF(a);
         return slow(name, args, kwds);
     }
 

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1788,6 +1788,7 @@ reducer(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
+        Py_DECREF(a);
         return slow(name, args, kwds);
     }
 


### PR DESCRIPTION
Close #351 by decref'ing `a` before returning the slow path.