### PR TITLE
PERF: int nansum contiguous case

### DIFF
--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -169,8 +169,8 @@ REDUCE_ONE(nansum, DTYPE0) {
             WHILE {
                 npy_DTYPE1 asum = 0;
                 const npy_DTYPE0* pa = PA(DTYPE0);
-                FOR {
-                    asum += SI(pa);
+                for(npy_intp i=0; i < LENGTH; i++) {
+                    asum += pa[i];
                 }
                 YPP = asum;
                 NEXT


### PR DESCRIPTION
Significant speedup in contiguous case:
```
$ asv compare HEAD^ HEAD -s --only-changed --sort ratio
       before           after         ratio
     [1975fa0c]       [143f52fb]
     <int_nansum~1>       <int_nansum_contig>
-         695±5μs          422±1μs     0.61  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'F', 0)
-         699±3μs          422±1μs     0.60  reduce.Time2DReductions.time_nansum('int64', (1000, 1000), 'C', 1)
```