### PR TITLE
use bool instead of np.bool

### DIFF
--- a/bottleneck/slow/move.py
+++ b/bottleneck/slow/move.py
@@ -164,7 +164,7 @@ def _mask(a, window, min_count, axis):
     idx3 = tuple(idx3)
     nidx1 = n[idx1]
     nidx1 = nidx1 - n[idx2]
-    idx = np.empty(a.shape, dtype=np.bool)
+    idx = np.empty(a.shape, dtype=bool)
     idx[idx1] = nidx1 < min_count
     idx[idx3] = n[idx3] < min_count
     return idx


### PR DESCRIPTION
numpy 1.20.0 deprecates `np.bool` etc, see.: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated. I found one usage of this in bottleneck, that causes some [warnings in xarray](https://github.com/pydata/xarray/runs/1653359233#step:7:369).