### PR TITLE
Fix get_python_header_include() for Python 3.10

### DIFF
--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -24,7 +24,8 @@ def get_python_header_include() -> List[str]:
     if sys.platform == "win32":
         suffix = ["include"]
     else:
-        suffix = ["include", "python" + sys.version[:3] + sys.abiflags]
+        python_ver = "python{0.major}.{0.minor}".format(sys.version_info)
+        suffix = ["include", python_ver + sys.abiflags]
 
     results = []
     for prefix in [sys.prefix, sys.exec_prefix]:


### PR DESCRIPTION
Don't use sys.version[:3] which doesn't work on "3.10.0a6 (...)"
string.