### PR TITLE
Add setuptools_scm as build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools>42",
+    "setuptools_scm[toml]",
     "wheel",
     "oldest-supported-numpy"
 ]


### PR DESCRIPTION
Hello, I was setting up some package depending on bottleneck and I was hitting the following error:

```shell
Collecting bottleneck<2.0.0,>=1.3.2
  Downloading ***/Bottleneck-1.3.2.tar.gz (88 kB)
  Installing build dependencies: started
  Installing build dependencies: still running...
  Installing build dependencies: still running...
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /opt/_internal/cpython-3.9.5/bin/python /opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmp_4atsqhp
         cwd: /tmp/pip-install-q6zczn_x/bottleneck_203584a53652418f9856423dafa7736c
    Complete output (32 lines):
    Traceback (most recent call last):
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 349, in <module>
        main()
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 331, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 151, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 166, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 258, in run_setup
        super(_BuildMetaLegacyBackend,
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 150, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 196, in <module>
        setup(**metadata)
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 453, in __init__
        _Distribution.__init__(
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/distutils/dist.py", line 292, in __init__
        self.finalize_options()
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 830, in finalize_options
        for ep in sorted(loaded, key=by_order):
      File "/tmp/pip-build-env-on7s05yo/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 829, in <lambda>
        loaded = map(lambda e: e.load(), filtered)
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2450, in load
        return self.resolve()
      File "/opt/_internal/cpython-3.9.5/lib/python3.9/site-packages/pkg_resources/__init__.py", line 2456, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
    ModuleNotFoundError: No module named 'setuptools_scm'
```

Adding `setuptools_scm` as build dep, fixes the problem