### PR TITLE
Mac M1 Support

### DIFF
--- a/bottleneck/include/bn_config.h
+++ b/bottleneck/include/bn_config.h
@@ -1,0 +1,6 @@
+#define HAVE_ATTRIBUTE_OPTIMIZE_OPT_3 0
+#define HAVE___BUILTIN_ISNAN 1
+#define HAVE_ISNAN 1
+#define HAVE__ISNAN 0
+/* undef inline */
+typedef int _make_iso_compilers_happy;

--- a/bottleneck/include/bn_config.h
+++ b/bottleneck/include/bn_config.h
@@ -1,6 +1,0 @@
-#define HAVE_ATTRIBUTE_OPTIMIZE_OPT_3 0
-#define HAVE___BUILTIN_ISNAN 1
-#define HAVE_ISNAN 1
-#define HAVE__ISNAN 0
-/* undef inline */
-typedef int _make_iso_compilers_happy;

--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -3,6 +3,7 @@ Unfortunately that file is not exposed, so re-implement the portions we need.
 """
 import os
 import sys
+import platform
 import textwrap
 from distutils.command.config import config as Config
 from typing import List
@@ -11,7 +12,9 @@ OPTIONAL_FUNCTION_ATTRIBUTES = [
     ("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3", '__attribute__((optimize("O3")))')
 ]
 
-OPTIONAL_HEADERS = []
+OPTIONAL_HEADERS = (
+    [] if platform.machine() == "arm64" else [("HAVE_SSE2", "emmintrin.h")]
+)
 
 OPTIONAL_INTRINSICS = [
     ("HAVE___BUILTIN_ISNAN", "__builtin_isnan", "0."),

--- a/bottleneck/src/bn_config.py
+++ b/bottleneck/src/bn_config.py
@@ -11,7 +11,7 @@ OPTIONAL_FUNCTION_ATTRIBUTES = [
     ("HAVE_ATTRIBUTE_OPTIMIZE_OPT_3", '__attribute__((optimize("O3")))')
 ]
 
-OPTIONAL_HEADERS = [("HAVE_SSE2", "emmintrin.h")]
+OPTIONAL_HEADERS = []
 
 OPTIONAL_INTRINSICS = [
     ("HAVE___BUILTIN_ISNAN", "__builtin_isnan", "0."),

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1313,7 +1313,7 @@ REDUCE_ONE(anynan, DTYPE0) {
 #else
                 for (npy_intp i = 0; (i < loop_count) && (f == 0); i++) {
                     for (npy_intp j = 0; j < LOOP_SIZE; j++) {
-                        ai = pa[vector_offset + i * LOOP_SIZE + j];
+                        const npy_DTYPE0 ai = pa[vector_offset + i * LOOP_SIZE + j];
                         f += bn_isnan(ai);
                     }
                 }
@@ -1517,7 +1517,7 @@ REDUCE_ONE(allnan, DTYPE0) {
 #else
                 for (npy_intp i = 0; (i < loop_count) && (f == 0); i++) {
                     for (npy_intp j = 0; j < LOOP_SIZE; j++) {
-                        ai = pa[vector_offset + i * LOOP_SIZE + j];
+                        const npy_DTYPE0 ai = pa[vector_offset + i * LOOP_SIZE + j];
                         f += !bn_isnan(ai);
                     }
                 }


### PR DESCRIPTION
Incorporated @NikZak's suggestion from https://github.com/pydata/bottleneck/issues/385#issuecomment-928035398 and also removed the emmintrin header on arm64 ARM per https://reviews.llvm.org/D109686#change-qMIOtz4d3wgp.

Tested like so:

```
$ SDKROOT=$(xcrun --sdk macosx --show-sdk-path) pip install -e .[test] && pytest .
...
===================================== test session starts ======================================
platform darwin -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/john/bottleneck, configfile: setup.cfg
plugins: hypothesis-6.34.1
collected 209 items                                                                            

bottleneck/tests/input_modification_test.py .............................                [ 13%]
bottleneck/tests/list_input_test.py .............................                        [ 27%]
bottleneck/tests/memory_test.py .                                                        [ 28%]
bottleneck/tests/move_test.py .................................                          [ 44%]
bottleneck/tests/nonreduce_axis_test.py .........................                        [ 55%]
bottleneck/tests/nonreduce_test.py ..............                                        [ 62%]
bottleneck/tests/reduce_test.py ........................................................ [ 89%]
...                                                                                      [ 90%]
bottleneck/tests/scalar_input_test.py ..................                                 [ 99%]
bottleneck/tests/test_template.py .                                                      [100%]

======================================= warnings summary =======================================
bottleneck/tests/scalar_input_test.py::test_scalar_input[ss]
  /Users/john/bottleneck/bottleneck/slow/reduce.py:87: RuntimeWarning: overflow encountered in multiply
    y = np.multiply(a, a).sum(axis)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================== 209 passed, 1 warning in 32.31s ================================
```