### PR TITLE
remove 'requires' metadata field deprecated for ~19 years

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,6 @@ metadata = dict(
         "bottleneck": ["LICENSE"],
         "bottleneck.tests": ["data/*/*"],
     },
-    requires=["numpy"],
     install_requires=["numpy"],
     extras_require={"doc": ["numpydoc", "sphinx", "gitpython"]},
     cmdclass=cmdclass,


### PR DESCRIPTION
The `Requires` field was deprecated with [PEP
345](https://peps.python.org/pep-0345/#summary-of-differences-from-pep-314) circa 2005.  [PEP
566](https://peps.python.org/pep-0566/#summary-of-differences-from-pep-345) circa 2017 introduced version 2.1 (used by bottleneck) of the metadata specification without any mention of `Requires`.

This is a problem because a tool working with Python packages might reasonably validate that the fields in the package metadata are valid per the specification.