### PR TITLE
Update Numpy build-time requirement (time sensitive)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,16 @@ requires = [
     "setuptools",
     "versioneer", 
     "wheel",
-    "oldest-supported-numpy"
+    "oldest-supported-numpy ; python_version < '3.9'",
+    # Comments on numpy build requirement range:
+    #
+    #   1. >=2.0.x is the numpy requirement for wheel builds for distribution
+    #      on PyPI - building against 2.x yields wheels that are also
+    #      ABI-compatible with numpy 1.x at runtime.
+    #   2. Note that building against numpy 1.x works fine too - users and
+    #      redistributors can do this by installing the numpy version they like
+    #      and disabling build isolation.
+    #   3. The <2.3 upper bound is for matching the numpy deprecation policy,
+    #      it should not be loosened
+    "numpy>=2.0.0rc1<2.3 ; python_version >= '3.9'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,10 @@ metadata = dict(
     install_requires=["numpy"],
     extras_require={"doc": ["numpydoc", "sphinx", "gitpython"]},
     cmdclass=cmdclass,
-    setup_requires=["numpy"],
+    setup_requires=[
+        "oldest-supported-numpy ; python_version < '3.9'",
+        "numpy>=2.0.0rc1 ; python_version >= '3.9'"
+    ],
     ext_modules=prepare_modules(),
     zip_safe=False,
 )


### PR DESCRIPTION
This PR does a few things:

* Since Numpy 1.25, the Numpy C API is backward-compatible and ``oldest-supported-numpy`` is no longer needed (see https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency for example), so we can get rid of ``oldest-supported-numpy`` in the build-time dependencies in ``pyproject.toml`` and just use ``numpy``
* As discussed in https://github.com/numpy/numpy/issues/24300#issuecomment-2030603395, packages that depend on the Numpy C API will need new wheels compiled against Numpy 2.0 in order to be compatible with both Numpy 1.x and 2.x. These wheels should ideally be released *before* Numpy 2.0 is released. As Numpy 2.0.0rc1 is out and the ABI is guaranteed to no longer change, the [recommendation](https://github.com/numpy/numpy/issues/24300#issuecomment-2030603395) from Numpy is that the build-time dependency on Numpy should be ``numpy>=2.0.0rc1``. Then, if/once this PR is merged, new wheels of bottleneck should ideally be built ASAP.
* I have also removed the deprecated ``requires=`` field from ``setup.py``, updated ``setup_requires`` to also require Numpy 2.0.0rc1 or later.
* Bump minimum required version of Python to 3.9 as Numpy 2.0 is not available on older versions and since Python 3.7 and 3.8 are now ancient.

Without this PR:

```
% python -m venv bt
% source bt/bin/activate
% pip install bottleneck numpy --pre
...
Successfully installed bottleneck-1.3.8 numpy-2.0.0rc1
% python -c "import bottleneck"

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0rc1 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "<string>", line 1, in <module>
  File "/Users/tom/tmp/bt/lib/python3.11/site-packages/bottleneck/__init__.py", line 7, in <module>
    from .move import (move_argmax, move_argmin, move_max, move_mean, move_median,
AttributeError: _ARRAY_API not found
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/tom/tmp/bt/lib/python3.11/site-packages/bottleneck/__init__.py", line 7, in <module>
    from .move import (move_argmax, move_argmin, move_max, move_mean, move_median,
ImportError: numpy.core.multiarray failed to import
```