### PR TITLE
MNT: No longer use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,15 @@ requires = [
     "setuptools",
     "versioneer", 
     "wheel",
-    "oldest-supported-numpy"
+    # Comments on numpy build requirement range:
+    #
+    #   1. >=2.0.x is the numpy requirement for wheel builds for distribution
+    #      on PyPI - building against 2.x yields wheels that are also
+    #      ABI-compatible with numpy 1.x at runtime.
+    #   2. Note that building against numpy 1.x works fine too - users and
+    #      redistributors can do this by installing the numpy version they like
+    #      and disabling build isolation.
+    #   3. The <2.3 upper bound is for matching the numpy deprecation policy,
+    #      it should not be loosened.
+    "numpy>=2.0.0rc1,<2.3",
 ]

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,10 @@ metadata = dict(
     install_requires=["numpy"],
     extras_require={"doc": ["numpydoc", "sphinx", "gitpython"]},
     cmdclass=cmdclass,
-    setup_requires=["numpy"],
+    setup_requires=[
+        "oldest-supported-numpy ; python_version < '3.9'",
+        "numpy>=2.0.0rc1 ; python_version >= '3.9'"
+    ],
     ext_modules=prepare_modules(),
     zip_safe=False,
 )


### PR DESCRIPTION
Since it is not needed anymore with recent Numpy versions, and bump minimum required Numpy to 2.0.0rc1 in order to be able to build Numpy 2-compatible wheels

Set build-time version of Numpy in setup.py for legacy installs

Make setup_requires consistent with pyproject.toml