### PR TITLE
Publish linux arm64 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        architecture: [x86, x64, arm64]
+        architecture: [x86, x64]
         os:
           [
             ubuntu-latest,
@@ -27,9 +27,18 @@ jobs:
             architecture: x86
           - os: macos-12
             architecture: x86
+        include:
+          - os: ubuntu-latest
+            architecture: arm64
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU (Linux/arm64 Only)
+        if: runner.os == 'Linux' && matrix.architecture == "arm64"
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        architecture: [x86, x64]
+        architecture: [x86, x64, arm64]
         os:
           [
             ubuntu-latest,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU (Linux Only)
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_SKIP: pp*
+          CIBW_ARCHS_LINUX: auto aarch64
 
       - name: Store wheel artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
We'd like to use bottleneck on Linux arm64 machines and it'd be great to consume a wheel instead of an sdist for that.

Following the guide at https://cibuildwheel.pypa.io/en/stable/faq/#emulation, cibuildwheel supports QEMU emulation to make the arm64 build work.