### PR TITLE
ENH: enable CPython free-threading support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
 
       - if: ${{ endsWith(matrix.python-version, 't') }}
-        run:
+        run: |
           pip install pytest-run-parallel
           echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:
-          CIBW_SKIP: pp*
+          CIBW_SKIP: "pp* *t-manylinux_i686 *t-musllinux_i686"
           CIBW_ENABLE: cpython-freethreading
 
       - name: Store wheel artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_SKIP: pp*
+          CIBW_ENABLE: cpython-freethreading
 
       - name: Store wheel artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         architecture: [x86, x64]
         os:
           [
@@ -29,10 +29,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: ${{ matrix.python-version != '3.13t' }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
+
+      - name: Set up free-threaded Python ${{ matrix.python-version }}
+        if: ${{ matrix.python-version == '3.13t' }}
+        uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: false
+
+      - if: ${{ matrix.python-version == '3.13t' }}
+        run:
+          uv pip install --python=${{ matrix.python-version }} pip
+          uv pip install --python=${{ matrix.python-version }} --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+          uv pip install --python=${{ matrix.python-version }} pytest-run-parallel
+          echo "PARALLEL_THREADS=4" >> "$GITHUB_ENV"
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,24 +29,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: ${{ matrix.python-version != '3.13t' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
 
-      - name: Set up free-threaded Python ${{ matrix.python-version }}
-        if: ${{ matrix.python-version == '3.13t' }}
-        uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: false
 
-      - if: ${{ matrix.python-version == '3.13t' }}
+      - if: ${{ endsWith(matrix.python-version, 't') }}
         run:
-          uv pip install --python=${{ matrix.python-version }} pip
-          uv pip install --python=${{ matrix.python-version }} --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-          uv pip install --python=${{ matrix.python-version }} pytest-run-parallel
+          pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+          pip install pytest-run-parallel
           echo "PARALLEL_THREADS=4" >> "$GITHUB_ENV"
 
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
@@ -37,9 +37,8 @@ jobs:
 
       - if: ${{ endsWith(matrix.python-version, 't') }}
         run:
-          pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
           pip install pytest-run-parallel
-          echo "PARALLEL_THREADS=4" >> "$GITHUB_ENV"
+          echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
 
       - name: Install
         run: |

--- a/bottleneck/conftest.py
+++ b/bottleneck/conftest.py
@@ -1,0 +1,32 @@
+
+import pytest
+
+try:
+    import pytest_run_parallel  # noqa:F401
+
+    PARALLEL_RUN_AVAILABLE = True
+except Exception:
+    PARALLEL_RUN_AVAILABLE = False
+
+
+def pytest_configure(config):
+    if not PARALLEL_RUN_AVAILABLE:
+        config.addinivalue_line(
+            'markers',
+            'parallel_threads(n): run the given test function in parallel '
+            'using `n` threads.',
+        )
+        config.addinivalue_line(
+            "markers",
+            "thread_unsafe: mark the test function as single-threaded",
+        )
+        config.addinivalue_line(
+            "markers",
+            "iterations(n): run the given test function `n` times in each thread",
+        )
+
+
+if not PARALLEL_RUN_AVAILABLE:
+    @pytest.fixture
+    def num_parallel_threads():
+        return 1

--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -1519,6 +1519,11 @@ PyInit_move(void)
 {
     PyObject *m = PyModule_Create(&move_def);
     if (m == NULL) return NULL;
+
+    #ifdef Py_GIL_DISABLED
+        PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+    #endif
+
     import_array();
     if (!intern_strings()) {
         return NULL;

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -1027,6 +1027,11 @@ PyInit_nonreduce_axis(void)
 {
     PyObject *m = PyModule_Create(&nra_def);
     if (m == NULL) return NULL;
+
+    #ifdef Py_GIL_DISABLED
+        PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+    #endif
+
     import_array();
     if (!intern_strings()) {
         return NULL;

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -345,6 +345,11 @@ PyInit_nonreduce(void)
 {
     PyObject *m = PyModule_Create(&nonreduce_def);
     if (m == NULL) return NULL;
+
+    #ifdef Py_GIL_DISABLED
+        PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+    #endif
+
     import_array();
     if (!intern_strings()) {
         return NULL;

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1966,6 +1966,11 @@ PyInit_reduce(void)
 {
     PyObject *m = PyModule_Create(&reduce_def);
     if (m == NULL) return NULL;
+
+    #ifdef Py_GIL_DISABLED
+        PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+    #endif
+
     import_array();
     if (!intern_strings()) {
         return NULL;

--- a/bottleneck/tests/memory_test.py
+++ b/bottleneck/tests/memory_test.py
@@ -4,6 +4,7 @@ import bottleneck as bn
 import pytest
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="resource module not available on windows"
 )

--- a/bottleneck/tests/test_template.py
+++ b/bottleneck/tests/test_template.py
@@ -1,9 +1,11 @@
 import os
 import posixpath as path
+import pytest
 
 from ..src.bn_template import make_c_files
 
 
+@pytest.mark.thread_unsafe
 def test_make_c_files() -> None:
     dirpath = os.path.join(os.path.dirname(__file__), "data/template_test/")
     modules = ["test"]


### PR DESCRIPTION
This PR enables free-threading builds of bottleneck, available from Python 3.13 onwards, this new distribution allows Python packages to leverage true parallel support, as the GIL is now optional. 

In particular, this PR performs the following checks:
- [x] Test the package using `pytest-run-parallel`, which allows pytest suites to be run concurrently (per test). This analysis didn't throw any major concurrency-related issues, the only tests that were marked as thread-unsafe were related to memory usage checking and concurrent file overwriting.
- [x] Add a CI to run tests in parallel, as well to build and release free-threaded wheels
- [x] Check package compliance using Thread Sanitizer (TSAN)
- [x] Marking each C module as free-threaded compatible