### PR TITLE
Remove Python 2.x support from C code

### DIFF
--- a/bottleneck/include/bottleneck.h
+++ b/bottleneck/include/bottleneck.h
@@ -36,12 +36,6 @@
 #define NPY_MIN_int64 NPY_MIN_INT64
 #define NPY_MIN_int32 NPY_MIN_INT32
 
-#if PY_MAJOR_VERSION >= 3
-    #define PyString_FromString       PyBytes_FromString
-    #define PyInt_AsLong              PyLong_AsLong
-    #define PyString_InternFromString PyUnicode_InternFromString
-#endif
-
 #define VARKEY              (((unsigned)METH_VARARGS) | ((unsigned)METH_KEYWORDS))
 #define error_converting(x) (((x) == -1) && PyErr_Occurred())
 

--- a/bottleneck/src/bottleneck.h
+++ b/bottleneck/src/bottleneck.h
@@ -32,12 +32,6 @@
 #define NPY_MIN_int64 NPY_MIN_INT64
 #define NPY_MIN_int32 NPY_MIN_INT32
 
-#if PY_MAJOR_VERSION >= 3
-    #define PyString_FromString PyBytes_FromString
-    #define PyInt_AsLong PyLong_AsLong
-    #define PyString_InternFromString PyUnicode_InternFromString
-#endif
-
 #define VARKEY METH_VARARGS | METH_KEYWORDS
 #define error_converting(x) (((x) == -1) && PyErr_Occurred())
 

--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -751,11 +751,11 @@ PyObject *pystr_ddof = NULL;
 
 static int
 intern_strings(void) {
-    pystr_a = PyString_InternFromString("a");
-    pystr_window = PyString_InternFromString("window");
-    pystr_min_count = PyString_InternFromString("min_count");
-    pystr_axis = PyString_InternFromString("axis");
-    pystr_ddof = PyString_InternFromString("ddof");
+    pystr_a = PyUnicode_InternFromString("a");
+    pystr_window = PyUnicode_InternFromString("window");
+    pystr_min_count = PyUnicode_InternFromString("min_count");
+    pystr_axis = PyUnicode_InternFromString("axis");
+    pystr_ddof = PyUnicode_InternFromString("ddof");
     return pystr_a && pystr_window && pystr_min_count &&
            pystr_axis && pystr_ddof;
 }
@@ -1504,7 +1504,6 @@ move_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef
 move_def = {
    PyModuleDef_HEAD_INIT,
@@ -1513,23 +1512,13 @@ move_def = {
    -1,
    move_methods
 };
-#endif
 
 
 PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
 #define RETVAL m
 PyInit_move(void)
-#else
-#define RETVAL
-initmove(void)
-#endif
 {
-    #if PY_MAJOR_VERSION >=3
-        PyObject *m = PyModule_Create(&move_def);
-    #else
-        PyObject *m = Py_InitModule3("move", move_methods, move_doc);
-    #endif
+    PyObject *m = PyModule_Create(&move_def);
     if (m == NULL) return RETVAL;
     import_array();
     if (!intern_strings()) {

--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -1515,14 +1515,13 @@ move_def = {
 
 
 PyMODINIT_FUNC
-#define RETVAL m
 PyInit_move(void)
 {
     PyObject *m = PyModule_Create(&move_def);
-    if (m == NULL) return RETVAL;
+    if (m == NULL) return NULL;
     import_array();
     if (!intern_strings()) {
-        return RETVAL;
+        return NULL;
     }
-    return RETVAL;
+    return m;
 }

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -392,10 +392,10 @@ PyObject *pystr_axis = NULL;
 
 static int
 intern_strings(void) {
-    pystr_a = PyString_InternFromString("a");
-    pystr_n = PyString_InternFromString("n");
-    pystr_kth = PyString_InternFromString("kth");
-    pystr_axis = PyString_InternFromString("axis");
+    pystr_a = PyUnicode_InternFromString("a");
+    pystr_n = PyUnicode_InternFromString("n");
+    pystr_kth = PyUnicode_InternFromString("kth");
+    pystr_axis = PyUnicode_InternFromString("axis");
     return pystr_a && pystr_n && pystr_axis;
 }
 
@@ -1012,7 +1012,6 @@ nra_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef
 nra_def = {
    PyModuleDef_HEAD_INIT,
@@ -1021,23 +1020,13 @@ nra_def = {
    -1,
    nra_methods
 };
-#endif
 
 
 PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
 #define RETVAL m
 PyInit_nonreduce_axis(void)
-#else
-#define RETVAL
-initnonreduce_axis(void)
-#endif
 {
-    #if PY_MAJOR_VERSION >=3
-        PyObject *m = PyModule_Create(&nra_def);
-    #else
-        PyObject *m = Py_InitModule3("nonreduce_axis", nra_methods, nra_doc);
-    #endif
+    PyObject *m = PyModule_Create(&nra_def);
     if (m == NULL) return RETVAL;
     import_array();
     if (!intern_strings()) {

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -1023,14 +1023,13 @@ nra_def = {
 
 
 PyMODINIT_FUNC
-#define RETVAL m
 PyInit_nonreduce_axis(void)
 {
     PyObject *m = PyModule_Create(&nra_def);
-    if (m == NULL) return RETVAL;
+    if (m == NULL) return NULL;
     import_array();
     if (!intern_strings()) {
-        return RETVAL;
+        return NULL;
     }
-    return RETVAL;
+    return m;
 }

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -341,14 +341,13 @@ nonreduce_def = {
 
 
 PyMODINIT_FUNC
-#define RETVAL m
 PyInit_nonreduce(void)
 {
     PyObject *m = PyModule_Create(&nonreduce_def);
-    if (m == NULL) return RETVAL;
+    if (m == NULL) return NULL;
     import_array();
     if (!intern_strings()) {
-        return RETVAL;
+        return NULL;
     }
-    return RETVAL;
+    return m;
 }

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -106,9 +106,9 @@ PyObject *pystr_new = NULL;
 
 static int
 intern_strings(void) {
-    pystr_a = PyString_InternFromString("a");
-    pystr_old = PyString_InternFromString("old");
-    pystr_new = PyString_InternFromString("new");
+    pystr_a = PyUnicode_InternFromString("a");
+    pystr_old = PyUnicode_InternFromString("old");
+    pystr_new = PyUnicode_InternFromString("new");
     return pystr_a && pystr_old && pystr_new;
 }
 
@@ -330,7 +330,6 @@ nonreduce_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef
 nonreduce_def = {
    PyModuleDef_HEAD_INIT,
@@ -339,24 +338,13 @@ nonreduce_def = {
    -1,
    nonreduce_methods
 };
-#endif
 
 
 PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
 #define RETVAL m
 PyInit_nonreduce(void)
-#else
-#define RETVAL
-initnonreduce(void)
-#endif
 {
-    #if PY_MAJOR_VERSION >=3
-        PyObject *m = PyModule_Create(&nonreduce_def);
-    #else
-        PyObject *m = Py_InitModule3("nonreduce", nonreduce_methods,
-                                     nonreduce_doc);
-    #endif
+    PyObject *m = PyModule_Create(&nonreduce_def);
     if (m == NULL) return RETVAL;
     import_array();
     if (!intern_strings()) {

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1059,9 +1059,9 @@ PyObject *pystr_ddof = NULL;
 
 static int
 intern_strings(void) {
-    pystr_a = PyString_InternFromString("a");
-    pystr_axis = PyString_InternFromString("axis");
-    pystr_ddof = PyString_InternFromString("ddof");
+    pystr_a = PyUnicode_InternFromString("a");
+    pystr_axis = PyUnicode_InternFromString("axis");
+    pystr_ddof = PyUnicode_InternFromString("ddof");
     return pystr_a && pystr_axis && pystr_ddof;
 }
 
@@ -1951,7 +1951,6 @@ reduce_methods[] = {
 };
 
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef
 reduce_def = {
    PyModuleDef_HEAD_INIT,
@@ -1960,23 +1959,13 @@ reduce_def = {
    -1,
    reduce_methods
 };
-#endif
 
 
 PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
 #define RETVAL m
 PyInit_reduce(void)
-#else
-#define RETVAL
-initreduce(void)
-#endif
 {
-    #if PY_MAJOR_VERSION >=3
-        PyObject *m = PyModule_Create(&reduce_def);
-    #else
-        PyObject *m = Py_InitModule3("reduce", reduce_methods, reduce_doc);
-    #endif
+    PyObject *m = PyModule_Create(&reduce_def);
     if (m == NULL) return RETVAL;
     import_array();
     if (!intern_strings()) {

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1962,14 +1962,13 @@ reduce_def = {
 
 
 PyMODINIT_FUNC
-#define RETVAL m
 PyInit_reduce(void)
 {
     PyObject *m = PyModule_Create(&reduce_def);
-    if (m == NULL) return RETVAL;
+    if (m == NULL) return NULL;
     import_array();
     if (!intern_strings()) {
-        return RETVAL;
+        return NULL;
     }
-    return RETVAL;
+    return m;
 }


### PR DESCRIPTION
This makes the code quite a bit easier to read, and the second commit fixes a tiny bug in the extension module initialization code (shouldn't happen in practice, since it's the path for error handling when interning a few short strings would fail).