### PR TITLE
MAINT: update maximum numpy version to build against

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,12 @@ requires = [
     #   2. Note that building against numpy 1.x works fine too - users and
     #      redistributors can do this by installing the numpy version they like
     #      and disabling build isolation.
-    #   3. The <2.3 upper bound is for matching the numpy deprecation policy,
-    #      it should not be loosened
-    "numpy>=2,<2.3"
+    #   3. The <2.(N+3) upper bound is for matching the numpy deprecation policy,
+    #      it should not be loosened more than that.
+    "numpy>=2,<2.5"
 ]
+
+
+[tool.pytest.ini_options]
+addopts = "-l"
+filterwarnings = ["error"]


### PR DESCRIPTION
The rule is <N+3, and numpy 2.2.x is out, so the bound should be <2.5.

Also add a `pytest.ini` file that will turn deprecation warnings in the test suite into errors. This will catch any deprecations from `numpy` or `python`, so that they can be fixed in time. Having the test suite run deprecation-warning-free is the guarantee that the <N+3 upper bound will work. The `pytest.ini` contents are derived from what NumPy and SciPy also use.