### PR TITLE
CI: bump ubuntu-20.04 to 22.04 in CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           [
             ubuntu-latest,
-            ubuntu-20.04,
+            ubuntu-22.04,
             macos-13,
             windows-latest,
             windows-2019,
@@ -20,7 +20,7 @@ jobs:
         exclude:
           - os: ubuntu-latest
             architecture: x86
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: x86
           - os: macos-13
             architecture: x86


### PR DESCRIPTION
20.04 is now failing, it is past the end of its announced deprecation period, see https://github.com/actions/runner-images/issues/11101