### PR TITLE
CI: add macOS arm64, Linux aarch, remove i686 wheels, trim test matrix

### DIFF
--- a/.github/bottleneck-action/action.yml
+++ b/.github/bottleneck-action/action.yml
@@ -1,0 +1,20 @@
+name: build-test-bottleneck
+description: "checkout repo, build, and test numpy"
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      shell: bash
+      run: |
+        pip install . -v
+
+    - name: Test with pytest
+      shell: bash
+      run: |
+        pip install pytest
+        cd doc  # avoid picking up bottleneck from the source dir
+        pytest --pyargs bottleneck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,40 @@ name: Github Actions
 on: ["push", "pull_request"]
 
 jobs:
-  test:
+  test-linux-macos:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
-        architecture: [x86, x64]
+        python-version: ["3.9", "3.13", "3.13t"]
         os:
-          [
-            ubuntu-latest,
-            ubuntu-22.04,
-            macos-13,
-            windows-latest,
-            windows-2019,
-          ]
-        exclude:
-          - os: ubuntu-latest
-            architecture: x86
-          - os: ubuntu-22.04
-            architecture: x86
-          - os: macos-13
-            architecture: x86
+          # Note that macos-13 is x86-64 (deprecated already),
+          # and macos-latest is arm64.
+          [ubuntu-22.04, ubuntu-24.04-arm, macos-13, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: |
+          pip install . -v
+
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          cd doc  # avoid picking up bottleneck from the source dir
+          pytest --pyargs bottleneck
+
+  test-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13", "3.13t"]
+        architecture: [x86, x64]
+        os: [windows-latest, windows-2019]
     steps:
       - uses: actions/checkout@v4
 
@@ -47,26 +59,26 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest
-          cd doc  # avoid picking up bottleneck from the source dir
+          cd doc
           pytest --pyargs bottleneck
 
   check:
     # This job is here is the "Required" one for merging PRs, and
-    # it only runs after all the `test` jobs above have run. Hence
+    # it only runs after all the `test-*` jobs above have run. Hence
     # it serves as a check that CI actually ran before a PR gets merged.
-    needs: test
+    needs: [test-linux-macos, test-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Placeholder for CI checks in PRs
         run: echo "Done"
 
   build_wheels:
-    needs: test
+    needs: [test-linux-macos, test-windows]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,7 +97,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_sdist:
-    needs: test
+    needs: [test-linux-macos, test-windows]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -102,7 +114,6 @@ jobs:
 
   release:
     needs: [build_wheels, build_sdist]
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:
-          CIBW_SKIP: "pp* *t-manylinux_i686 *t-musllinux_i686"
+          CIBW_SKIP: "pp* *_i686"
           CIBW_ENABLE: cpython-freethreading
 
       - name: Store wheel artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.13", "3.13t"]
+        python-version: ["3.9", "3.13"]
         os:
           # Note that macos-13 is x86-64 (deprecated already),
           # and macos-latest is arm64.
           [ubuntu-22.04, ubuntu-24.04-arm, macos-13, macos-latest]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install
-        run: |
-          pip install . -v
-
-      - name: Test with pytest
-        run: |
-          pip install pytest
-          cd doc  # avoid picking up bottleneck from the source dir
-          pytest --pyargs bottleneck
+      - uses: ./.github/bottleneck-action
 
   test-windows:
     runs-on: ${{ matrix.os }}
@@ -39,28 +25,16 @@ jobs:
         os: [windows-latest, windows-2019]
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/bottleneck-action
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-
-
-      - if: ${{ endsWith(matrix.python-version, 't') }}
-        run: |
-          pip install pytest-run-parallel
-          echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
-
-      - name: Install
-        run: |
-          pip install . -v
-
-      - name: Test with pytest
-        run: |
-          pip install pytest
-          cd doc
-          pytest --pyargs bottleneck
+  test-pyversions:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/bottleneck-action
 
   check:
     # This job is here is the "Required" one for merging PRs, and


### PR DESCRIPTION
This modernizes the CI setup to do the following:

- Test jobs that runs on PRs:
    - Adds macOS arm64
    - Adds Linux aarch64
    - Removes running duplicate jobs on `ubuntu-22.04` and `ubuntu-latest` (both x86-64, not useful)
    - Removes running jobs for every single minor Python version, but rather runs mininum (3.9), maximum (3.13) supported versions + free-threading (3.13t)
    - Refactors the test matrix so it's easier to read (no more  `exclude`) jobs
- Wheel build jobs (logs from a wheel build run [here](https://github.com/rgommers/bottleneck/actions/runs/14933404774/job/41955095607)):
    - Restores macOS x86-64 (those went missing from recent releases due to `macos-latest` switching from x86-64 to arm64, see e.g. https://pypi.org/project/Bottleneck/1.4.2/#files)
    - Adds Linux aarch64
    - Removes 32-bit Linux jobs (those are super slow and not useful, because NumPy stopped shipping i686 wheels a while back

I left the `windows-2019`/`windows-latest` test jobs duplication; that's probably also not useful, but it's harder to be sure of that than on Linux. Windows arm64 can be added later, once NumPy 2.3.0 publishes `win-arm64` wheels.

Adds the platforms as proposed in gh-474
Closes gh-464
Closes gh-395
Closes gh-394