### PR TITLE
Fix some build warnings and mistakes in pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.rst RELEASE.rst
 include LICENSE
-include Makefile tox.ini
+include Makefile
 include pyproject.toml
 
 graft LICENSES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     #      it should not be loosened more than that.
     "numpy>=2,<2.5"
 ]
+build-backend = "setuptools.build_meta"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools",
     "versioneer", 
-    "wheel",
     # Comments on numpy build requirement range:
     #
     #   1. >=2.0.x is the numpy requirement for wheel builds for distribution

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,6 @@ CLASSIFIERS = [
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Financial and Insurance Industry",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: C",
     "Programming Language :: Python",


### PR DESCRIPTION
This PR fixes some build warnings that were visible in CI logs, as well as two mistakes in `pyproject.toml`. In addition it would be good to start using the `[project]` section of `pyproject.toml` (because `setuptools` is discouraging/deprecation/removing alternatives, see [here](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged)), but that's more involved so left for another PR.

The warnings were:
```
      warning: no files found matching 'tox.ini'
    
      Running command Preparing metadata (pyproject.toml)
      /tmp/pip-build-env-ua_ysm8p/overlay/lib/python3.12/site-packages/setuptools/dist.py:761: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
    
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
    
              License :: OSI Approved :: BSD License
    
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
```

`pyproject.toml` changes:
- Remove `wheel` as a build dependency. This hasn't been necessary in a long time. `setuptools` takes care of building a wheel, and whatever dependency it may need for that.
- Fix missing `build-backend` key. This is a clear bug, `setuptools` only accepts having a `build-requires` section but no `build-backend` key either accidentally or for historical reasons, and will stop doing so at some point.
