### PR TITLE
MAINT: fix warning about `pp_*` skip selector for PyPy wheels not being needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CIBW_SKIP: "pp* *_i686"
+          CIBW_SKIP: "*_i686"
           CIBW_ENABLE: cpython-freethreading
 
       - name: Store wheel artifacts


### PR DESCRIPTION
This is a follow-up to gh-481, which moved to cibuildwheel 3.x which removed PyPy from the default set of wheels being built.