### PR TITLE
WHL: re-add macos-intel to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
+        os: 
+          - macos-15-intel
+          - macos-latest
+          - windows-latest
+          - ubuntu-latest
+          - ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Searching through the history I couldn't find why this target was dropped between 1.3.8 and 1.4.0rc4, so my current assumption is that it happened by accident, when the `macos-latest` image tag moved from an x86_64 runner to arm64. While I was surprise to find bottleneck needed to be built to install it on an old mac, it did build succesfully so I don't know of any blocking issue, so I'd like to propose re-introducing it on purpose.