### PR TITLE
MNT: setup auto-upgrades for GHA through dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /.github/workflows
+  schedule:
+    interval: quarterly
+  cooldown:
+    default-days: 7
+  groups:
+    # major upgrades get a dedicated PR each
+    # other upgrades are grouped by level
+    gha-minors:
+      update-types:
+      - minor
+    gha-patches:
+      update-types:
+      - patch


### PR DESCRIPTION
Based off #494 (only the last commit on the branch is exclusive to this PR)