### PR TITLE
CLN: cleanup python 2-only dead code blocks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,10 +68,7 @@ class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # prevent numpy from thinking it is still in its setup process
-        if sys.version_info < (3,):
-            import __builtin__ as builtins
-        else:
-            import builtins
+        import builtins
         builtins.__NUMPY_SETUP__ = False
         import numpy
 

--- a/tools/appveyor/conda_wrapper.py
+++ b/tools/appveyor/conda_wrapper.py
@@ -5,19 +5,6 @@ import sys
 import logging
 from subprocess import check_output
 
-
-if sys.version_info[0] == 2:
-
-    def decode(string):
-        return string
-
-
-else:
-
-    def decode(string):
-        return string.decode()
-
-
 class CondaWrapper(object):
     """Manage the AppVeyor Miniconda installation through Python.
 
@@ -54,14 +41,14 @@ class CondaWrapper(object):
             "no",
         ]
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         self.logger.info("Done.")
 
     def update(self):
         self.logger.info("Updating '%s'...", self.home)
         cmd = ["conda", "update", "-q", "conda"]
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         self.logger.info("Done.")
 
     def create(self, *args):
@@ -75,15 +62,15 @@ class CondaWrapper(object):
             "python=" + self.version,
         ] + list(args)
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         cmd = ["activate", self.venv]
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         # consider only for debugging
         cmd = ["conda", "info", "-a"]
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         cmd = ["conda", "list"]
         msg = check_output(cmd, shell=True)
-        self.logger.debug(decode(msg))
+        self.logger.debug(msg.decode())
         self.logger.info("Done.")


### PR DESCRIPTION
Exhaustive autofix done with

```
ruff check --select UP036 --fix --unsafe-fixes
```

then manually edited to remove the `decode` function entirely