### PR TITLE
DOC: adjust GHA badge on README to only report failures on `master`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-.. image:: https://github.com/pydata/bottleneck/workflows/Github%20Actions/badge.svg
-    :target: https://github.com/pydata/bottleneck/actions
+.. image:: https://github.com/pydata/bottleneck/actions/workflows/ci.yml/badge.svg?branch=master
+    :target: https://github.com/pydata/bottleneck/actions/workflows/ci.yml
+
 
 ==========
 Bottleneck


### PR DESCRIPTION
Currently the badge blindly reports whatever ran most recently, including unstable PR branches.