### PR TITLE
CI: pin Python 3.14t to exact patch version on windows-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             python-version: "3.14"
           - os: windows-11-arm
             architecture: arm64
-            python-version: "3.14.1t"
+            python-version: "3.14.0t"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/bottleneck-action


### PR DESCRIPTION
tentative workaround to restore CI stability