### PR TITLE
CI: drop now redundant pre-commit job from GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,6 @@ on: ["push", "pull_request"]
 permissions: {}
 
 jobs:
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      with:
-        persist-credentials: false
-    - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-
   test-linux-macos:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
now that we have pre-commit.ci up and running, this job shouldn't be needed