### PR TITLE
CI: drop now unneeded pip upgrade

### DIFF
--- a/.github/bottleneck-action/action.yml
+++ b/.github/bottleneck-action/action.yml
@@ -9,9 +9,7 @@ runs:
         python-version: ${{ matrix.python-version }}
     - name: Install
       shell: bash
-      run: |
-        pip install --upgrade pip
-        pip install . -v --group test
+      run: pip install . -v --group test
 
     - name: Test with pytest
       shell: bash


### PR DESCRIPTION
I don't think this line is needed any more. Presumably resolves failures seen on windows
```
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.14.2\x64\python.exe -m pip install --upgrade pip
```