### PR TITLE
WHL: enable Limited API-compliant (abi3) wheels

### DIFF
--- a/bottleneck/src/bottleneck.h
+++ b/bottleneck/src/bottleneck.h
@@ -7,6 +7,11 @@
 #include <numpy/arrayobject.h>
 #include <bn_config.h>
 
+#ifdef Py_LIMITED_API
+    #define PyTuple_GET_ITEM PyTuple_GetItem
+    #define PyTuple_GET_SIZE PyTuple_Size
+#endif
+
 /* THREADS=1 releases the GIL but increases function call
  * overhead. THREADS=0 does not release the GIL but keeps
  * function call overhead low. Curly brackets are for C89

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ skip = [
     "*_i686",
     "cp310-win_arm64", # no numpy wheels for this target
 ]
+environment = { "BN_LIMITED_API" = "1" }
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ test-sources = ["pyproject.toml"]
 test-command = [
     "pytest --pyargs bottleneck",
 ]
+environment = { "BN_LIMITED_API" = "1" }
 
 [tool.ruff]
 exclude = [

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import sysconfig
 from distutils.command.config import config as _config
 
 from setuptools import Command, setup
@@ -11,10 +12,22 @@ from setuptools.extension import Extension
 
 import versioneer
 
+# restrict LIMITED_API usage:
+# - require BN_LIMITED_API=1
+# - LIMITED_API is not compatible with free-threading (as of CPython 3.14)
+USE_PY_LIMITED_API = os.getenv(
+    "BN_LIMITED_API", "0"
+) == "1" and not sysconfig.get_config_var("Py_GIL_DISABLED")
+ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
+ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
+
+
 define_macros = [
     # keep in sync with runtime requirements (pyproject.toml)
     ("NPY_NO_DEPRECATED_API", "NPY_1_21_API_VERSION"),
 ]
+if USE_PY_LIMITED_API:
+    define_macros.append(("Py_LIMITED_API", ABI3_TARGET_HEX))
 
 
 class config(_config):
@@ -151,6 +164,11 @@ def prepare_modules():
     return ext
 
 
+if USE_PY_LIMITED_API:
+    options = {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
+else:
+    options = {}
+
 setup(
     version=versioneer.get_version(),
     package_data={
@@ -158,4 +176,5 @@ setup(
     },
     cmdclass=cmdclass,
     ext_modules=prepare_modules(),
+    options=options,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import sysconfig
 from distutils.command.config import config as _config
 
 from setuptools import Command, setup
@@ -11,10 +12,22 @@ from setuptools.extension import Extension
 
 import versioneer
 
+# restrict LIMITED_API usage:
+# - require BN_LIMITED_API=1
+# - LIMITED_API is not compatible with free-threading (as of CPython 3.14)
+USE_PY_LIMITED_API = os.getenv(
+    "BN_LIMITED_API", "0"
+) == "1" and not sysconfig.get_config_var("Py_GIL_DISABLED")
+ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
+ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
+
+
 define_macros = [
     # keep in sync with runtime requirements (pyproject.toml)
     ("NPY_NO_DEPRECATED_API", "NPY_1_23_API_VERSION"),
 ]
+if USE_PY_LIMITED_API:
+    define_macros.append(("Py_LIMITED_API", ABI3_TARGET_HEX))
 
 
 class config(_config):
@@ -151,6 +164,11 @@ def prepare_modules():
     return ext
 
 
+if USE_PY_LIMITED_API:
+    options = {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
+else:
+    options = {}
+
 setup(
     version=versioneer.get_version(),
     package_data={
@@ -158,4 +176,5 @@ setup(
     },
     cmdclass=cmdclass,
     ext_modules=prepare_modules(),
+    options=options,
 )


### PR DESCRIPTION
I initially just wanted to experiment with this and see how far from a working state we were... turns out the existing code is pretty close already, so only a couple tweaks were needed.

`PyTuple_GET_*` functions are normally faster, as they skip certain checks that equivalent Limited API functions will run, so there could be a case to be made that we should still use them by default, but I'm not convinced that the impact is even measurable (I'll run the benchmarks to double check before I undraft though).