### PR TITLE
Drop 3.13t builds from cibuildwheel configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,6 @@ skip = [
     "*_i686",
     "cp310-win_arm64", # no numpy wheels for this target
 ]
-enable = [
-    # enable cp313t wheels
-    # note that cp314t and later are already enabled by default
-    "cpython-freethreading",
-]
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

This option will be removed in the next release of cibuildwheel.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.