### PR TITLE
WHL: switch build frontend from `build[uv]` to `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ addopts = "-l"
 filterwarnings = ["error"]
 
 [tool.cibuildwheel]
-build-frontend = "build[uv]"
+build-frontend = "uv; args: --no-config"
 skip = [
     "*_i686",
     "cp310-win_arm64", # no numpy wheels for this target


### PR DESCRIPTION
taken out of #556