### PR TITLE
skip length-one axes when choosing flat stride in init_iter_all

### DIFF
--- a/bottleneck/src/iterators.h
+++ b/bottleneck/src/iterators.h
@@ -105,9 +105,10 @@ init_iter_all(iter *it, PyArrayObject *a, int ravel, int anyorder)
         it->length = PyArray_SIZE(a);
         it->astride = 0;
         for (i=ndim-1; i > -1; i--) {
-            /* protect against length zero  strides such as in
-             * np.ones((2, 2))[..., np.newaxis] */
-            if (strides[i] == 0) {
+            /* skip length-one axes and zero strides; their stride is never
+             * traversed and may be arbitrarily large in a transposed view
+             * such as np.zeros((1, 500, 2)).transpose(1, 2, 0) */
+            if (shape[i] == 1 || strides[i] == 0) {
                 continue;
             }
             it->astride = strides[i];
@@ -119,9 +120,10 @@ init_iter_all(iter *it, PyArrayObject *a, int ravel, int anyorder)
             it->length = PyArray_SIZE(a);
             it->astride = 0;
             for (i=0; i < ndim; i++) {
-                /* protect against length zero  strides such as in
-                 * np.ones((2, 2), order='F')[np.newaxis, ...] */
-                if (strides[i] == 0) {
+                /* skip length-one axes and zero strides; their stride is never
+                 * traversed and may be arbitrarily large in a transposed view
+                 * such as np.zeros((1, 192, 121)).transpose(0, 2, 1) */
+                if (shape[i] == 1 || strides[i] == 0) {
                     continue;
                 }
                 it->astride = strides[i];

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -212,7 +212,9 @@ def test_nanstd_issue60():
         # issue #381 (C-contiguous branch)
         np.zeros((1, 500, 2)).transpose(1, 2, 0),
         # issue #393 (F-contiguous branch)
-        np.arange(1 * 192 * 121, dtype=np.float64).reshape(1, 192, 121).transpose(0, 2, 1),
+        np.arange(1 * 192 * 121, dtype=np.float64)
+        .reshape(1, 192, 121)
+        .transpose(0, 2, 1),
     ),
     ids=("C-contiguous", "F-contiguous"),
 )

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -206,6 +206,25 @@ def test_nanstd_issue60():
     assert_equal(f, s, err_msg="issue #60 regression")
 
 
+def test_reduce_all_size_one_stride():
+    """reduce-all regression test (issues #381, #393)
+
+    A transposed view whose size-1 axis carries a large stride used to make
+    init_iter_all pick that stride as the flat element stride and iterate off
+    the buffer (garbage on the C-contiguous branch, segfault on the
+    F-contiguous branch).
+    """
+
+    # issue #381 (C-contiguous branch)
+    a = np.zeros((1, 500, 2)).transpose(1, 2, 0)
+    assert_equal(bn.nanmax(a), bn.slow.nanmax(a))
+
+    # issue #393 (F-contiguous branch)
+    b = np.arange(1 * 192 * 121, dtype=np.float64).reshape(1, 192, 121)
+    b = b.transpose(0, 2, 1)
+    assert_equal(bn.nanmax(b), bn.slow.nanmax(b))
+
+
 def test_nanvar_issue60():
     """nanvar regression test (issue #60)"""
 

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -214,7 +214,7 @@ def test_nanstd_issue60():
         # issue #393 (F-contiguous branch)
         np.arange(1 * 192 * 121, dtype=np.float64).reshape(1, 192, 121).transpose(0, 2, 1),
     ),
-    ids=("issue381", "issue393"),
+    ids=("C-contiguous", "F-contiguous"),
 )
 def test_reduce_all_size_one_stride(a):
     """reduce-all regression test (issues #381, #393)

--- a/bottleneck/tests/reduce_test.py
+++ b/bottleneck/tests/reduce_test.py
@@ -206,7 +206,17 @@ def test_nanstd_issue60():
     assert_equal(f, s, err_msg="issue #60 regression")
 
 
-def test_reduce_all_size_one_stride():
+@pytest.mark.parametrize(
+    "a",
+    (
+        # issue #381 (C-contiguous branch)
+        np.zeros((1, 500, 2)).transpose(1, 2, 0),
+        # issue #393 (F-contiguous branch)
+        np.arange(1 * 192 * 121, dtype=np.float64).reshape(1, 192, 121).transpose(0, 2, 1),
+    ),
+    ids=("issue381", "issue393"),
+)
+def test_reduce_all_size_one_stride(a):
     """reduce-all regression test (issues #381, #393)
 
     A transposed view whose size-1 axis carries a large stride used to make
@@ -214,15 +224,7 @@ def test_reduce_all_size_one_stride():
     the buffer (garbage on the C-contiguous branch, segfault on the
     F-contiguous branch).
     """
-
-    # issue #381 (C-contiguous branch)
-    a = np.zeros((1, 500, 2)).transpose(1, 2, 0)
     assert_equal(bn.nanmax(a), bn.slow.nanmax(a))
-
-    # issue #393 (F-contiguous branch)
-    b = np.arange(1 * 192 * 121, dtype=np.float64).reshape(1, 192, 121)
-    b = b.transpose(0, 2, 1)
-    assert_equal(bn.nanmax(b), bn.slow.nanmax(b))
 
 
 def test_nanvar_issue60():


### PR DESCRIPTION
When a reduce-all function gets a transposed view whose size-1 axis carries a large stride (`np.zeros((1,500,2)).transpose(1,2,0)`, `np.zeros((1,192,121)).transpose(0,2,1)`), the stride-picking loops in init_iter_all skip only zero strides and grab that axis's huge stride, so iteration runs off the buffer (issues #381, #393: garbage from nanmax or a segfault). Skip length-one axes there too, since their stride is never traversed.