### PR TITLE
free output array and median heap on window==1 in move_median

### DIFF
--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -564,6 +564,7 @@ MOVE(move_median, DTYPE0) {
     mm_handle *mm = mm_new_nan(window, min_count);
     INIT(NPY_DTYPE0)
     if (window == 1) {
+        Py_DECREF(y);
         mm_free(mm);
         return PyArray_Copy(a);
     }
@@ -599,6 +600,8 @@ MOVE(move_median, DTYPE0) {
     mm_handle *mm = mm_new(window, min_count);
     INIT(NPY_DTYPE1)
     if (window == 1) {
+        Py_DECREF(y);
+        mm_free(mm);
         return PyArray_CastToType(a,
                                   PyArray_DescrFromType(NPY_DTYPE1),
                                   PyArray_CHKFLAGS(a, NPY_ARRAY_F_CONTIGUOUS));


### PR DESCRIPTION
move_median allocates its output array with PyArray_EMPTY in INIT, then both dtype variants take an early return when window is 1. The float variant frees the median heap there but leaks that output array; the integer variant leaks both the array and the heap because it never calls mm_free either. I noticed it reading the two siblings side by side. Repeated calls with window=1 leak an input-sized array every time, so it accumulates fast. Free the array and the heap before returning, matching the normal exit path.