### PR TITLE
TST: fixup pytest's conftest.py discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ parentdir_prefix = "bottleneck-"
 [tool.pytest.ini_options]
 addopts = "-l"
 filterwarnings = ["error"]
+testpaths = ["bottleneck/tests"]
 
 [tool.cibuildwheel]
 build-frontend = "uv; args: --no-config"


### PR DESCRIPTION
This ensures that all hooks from `bottleneck/tests/conftest.py` are always run.