### PR TITLE
WHL: drop win32 support (stop distributing wheels)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,6 @@ jobs:
           archs: arm64
           select: '*'
         - os: windows-latest
-          archs: x86
-          select: '*'
-        - os: windows-latest
           archs: AMD64
           select: '*'
         - os: windows-11-arm


### PR DESCRIPTION
Following numpy
https://mail.python.org/archives/list/numpy-discussion@python.org/thread/FGVCDS5JICVIUVBISGWZNQ46QZ3XX5PB/#TTSOQQ3XLXXK52CZYMN7MALJQEI65UDN