### PR TITLE
DEP: drop support for numpy 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,8 @@ requires = [
     "setuptools>=77.0.1",
     "versioneer>=0.29",
     "versioneer[toml] ; python_version < '3.11'",
-    # Comments on numpy build requirement range:
-    #
-    #   1. >=2.0.x is the numpy requirement for wheel builds for distribution
-    #      on PyPI - building against 2.x yields wheels that are also
-    #      ABI-compatible with numpy 1.x at runtime.
-    #   2. Note that building against numpy 1.x works fine too - users and
-    #      redistributors can do this by installing the numpy version they like
-    #      and disabling build isolation.
-    #   3. The <2.(N+3) upper bound is for matching the numpy deprecation policy,
-    #      it should not be loosened more than that.
-    "numpy>=2,<2.6"
+    # The upper bound should be 3 minor releases ahead of the current runtime version
+    "numpy>=2,<2.8"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -52,7 +43,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     # keep in sync with NPY_* macros (setup.py)
-    "numpy>=1.23.2",
+    "numpy>=2.0.0",
 ]
 dynamic = ["version"]
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import versioneer
 
 define_macros = [
     # keep in sync with runtime requirements (pyproject.toml)
-    ("NPY_NO_DEPRECATED_API", "NPY_1_23_API_VERSION"),
+    ("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION"),
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy", specifier = ">=1.23.2" }]
+requires-dist = [{ name = "numpy", specifier = ">=2.0.0" }]
 
 [package.metadata.requires-dev]
 concurrency = [


### PR DESCRIPTION
Originally suggested by @rgommers in https://github.com/pydata/bottleneck/pull/556#pullrequestreview-5186485782 to help simplify the build process with meson.
