### PR TITLE
RFC: explicitly cast arguments to `Py_INCREF` and `Py_DECREF`

### DIFF
--- a/bottleneck/src/move_template.c
+++ b/bottleneck/src/move_template.c
@@ -926,7 +926,7 @@ mover(char *name,
     /* convert to array if necessary */
     if (PyArray_Check(a_obj)) {
         a = (PyArrayObject *)a_obj;
-        Py_INCREF(a);
+        Py_INCREF((PyObject*)a);
     } else {
         a = (PyArrayObject *)PyArray_FROM_O(a_obj);
         if (a == NULL) {
@@ -936,7 +936,7 @@ mover(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
-        Py_DECREF(a);
+        Py_DECREF((PyObject *)a);
         return slow(name, args, kwds);
     }
 
@@ -1030,12 +1030,12 @@ mover(char *name,
         y = slow(name, args, kwds);
     }
 
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
 
     return y;
 
 error:
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
     return NULL;
 
 }

--- a/bottleneck/src/nonreduce_axis_template.c
+++ b/bottleneck/src/nonreduce_axis_template.c
@@ -62,7 +62,7 @@ NRA(partition, DTYPE0) {
         PyErr_Format(PyExc_ValueError,
                      "`n` (=%d) must be between 0 and %zd, inclusive.",
                      n, LENGTH - 1);
-        Py_DECREF(a);
+        Py_DECREF((PyObject *)a);
         return NULL;
     }
 
@@ -659,7 +659,7 @@ nonreducer_axis(char *name,
     /* convert to array if necessary */
     if (PyArray_Check(a_obj)) {
         a = (PyArrayObject *)a_obj;
-        Py_INCREF(a);
+        Py_INCREF((PyObject*)a);
     } else {
         a = (PyArrayObject *)PyArray_FROM_O(a_obj);
         if (a == NULL) {
@@ -669,7 +669,7 @@ nonreducer_axis(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
-        Py_DECREF(a);
+        Py_DECREF((PyObject *)a);
         return slow(name, args, kwds);
     }
 
@@ -685,7 +685,7 @@ nonreducer_axis(char *name,
         } else {
             if (PyArray_NDIM(a) != 1) {
                 PyArrayObject *tmp = (PyArrayObject *)PyArray_Ravel(a, NPY_CORDER);
-                Py_DECREF(a);
+                Py_DECREF((PyObject *)a);
                 if (tmp == NULL) return NULL;
                 a = tmp;
             }
@@ -698,7 +698,7 @@ nonreducer_axis(char *name,
         }
         if (PyArray_NDIM(a) != 1) {
             PyArrayObject *tmp = (PyArrayObject *)PyArray_Ravel(a, NPY_CORDER);
-            Py_DECREF(a);
+            Py_DECREF((PyObject *)a);
             if (tmp == NULL) return NULL;
             a = tmp;
         }
@@ -746,12 +746,12 @@ nonreducer_axis(char *name,
     else if (dtype == NPY_int32)   y = nra_int32(a, axis, n);
     else                           y = slow(name, args, kwds);
 
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
 
     return y;
 
 error:
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
     return NULL;
 
 }

--- a/bottleneck/src/nonreduce_template.c
+++ b/bottleneck/src/nonreduce_template.c
@@ -47,7 +47,7 @@ replace_DTYPE0(PyArrayObject *a, double old, double new) {
         }
     }
     BN_END_ALLOW_THREADS
-    Py_INCREF(a);
+    Py_INCREF((PyObject*)a);
     return (PyObject *)a;
 }
 /* dtype end */
@@ -82,7 +82,7 @@ replace_DTYPE0(PyArrayObject *a, double old, double new) {
         }
         BN_END_ALLOW_THREADS
     }
-    Py_INCREF(a);
+    Py_INCREF((PyObject*)a);
     return (PyObject *)a;
 }
 /* dtype end */
@@ -210,7 +210,7 @@ nonreducer(char *name,
     /* convert to array if necessary */
     if (PyArray_Check(a_obj)) {
         a = (PyArrayObject *)a_obj;
-        Py_INCREF(a);
+        Py_INCREF((PyObject*)a);
     } else {
         if (inplace) {
             TYPE_ERR("works in place so input must be an array, "
@@ -225,7 +225,7 @@ nonreducer(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
-        Py_DECREF(a);
+        Py_DECREF((PyObject *)a);
         return slow(name, args, kwds);
     }
 
@@ -261,12 +261,12 @@ nonreducer(char *name,
     else if (dtype == NPY_int32)   y = nr_int32(a, old, new);
     else                           y = slow(name, args, kwds);
 
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
 
     return y;
 
 error:
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
     return NULL;
 
 }

--- a/bottleneck/src/reduce_template.c
+++ b/bottleneck/src/reduce_template.c
@@ -1189,7 +1189,7 @@ reducer(char *name,
     /* convert to array if necessary */
     if (PyArray_Check(a_obj)) {
         a = (PyArrayObject *)a_obj;
-        Py_INCREF(a);
+        Py_INCREF((PyObject*)a);
     } else {
         a = (PyArrayObject *)PyArray_FROM_O(a_obj);
         if (a == NULL) {
@@ -1199,7 +1199,7 @@ reducer(char *name,
 
     /* check for byte swapped input array */
     if (PyArray_ISBYTESWAPPED(a)) {
-        Py_DECREF(a);
+        Py_DECREF((PyObject *)a);
         return slow(name, args, kwds);
     }
 
@@ -1271,12 +1271,12 @@ reducer(char *name,
 
     }
 
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
 
     return y;
 
 error:
-    Py_DECREF(a);
+    Py_DECREF((PyObject *)a);
     return NULL;
 
 }


### PR DESCRIPTION
This resolves a bunch of compile-time warnings that are treated as errors on the meson branch (#556).
